### PR TITLE
Create `PerformanceCharge` with play name. Migrate play name from `Performance.play`

### DIFF
--- a/Theatrical-Players-Refactoring-Kata/Performance.swift
+++ b/Theatrical-Players-Refactoring-Kata/Performance.swift
@@ -3,7 +3,7 @@ struct Performance {
     let audience: Int
     
     var charge: PerformanceCharge
-    var play: Play?
+    
     var cost: Int?
     var volumeCredits: Int?
     
@@ -11,7 +11,6 @@ struct Performance {
         self.playID = playID
         self.audience = audience
         self.charge = charge
-        self.play = play
         self.cost = cost
         self.volumeCredits = volumeCredits
     }

--- a/Theatrical-Players-Refactoring-Kata/Performance.swift
+++ b/Theatrical-Players-Refactoring-Kata/Performance.swift
@@ -2,7 +2,21 @@ struct Performance {
     let playID: String
     let audience: Int
     
+    var charge: PerformanceCharge
     var play: Play?
     var cost: Int?
     var volumeCredits: Int?
+    
+    init(playID: String, audience: Int, charge: PerformanceCharge = .init(playName: "Placeholder"), play: Play? = nil, cost: Int? = nil, volumeCredits: Int? = nil) {
+        self.playID = playID
+        self.audience = audience
+        self.charge = charge
+        self.play = play
+        self.cost = cost
+        self.volumeCredits = volumeCredits
+    }
+}
+
+struct PerformanceCharge {
+    let playName: String
 }

--- a/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -22,7 +22,6 @@ class StatementPrinter {
             var result = performance
             result.charge = .init(playName: try play(for: result.playID).name)
             
-            result.play = try play(for: result.playID)
             result.cost = try costFor(try play(for: result.playID).genre, attendanceCount: result.audience)
             result.volumeCredits = volumeCreditsFor(try play(for: result.playID).genre, attendanceCount: result.audience)
             return result

--- a/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -20,6 +20,7 @@ class StatementPrinter {
         
         func enrich(_ performance: Performance) throws -> Performance {
             var result = performance
+            result.charge = .init(playName: try play(for: result.playID).name)
             result.play = try play(for: result.playID)
             result.cost = try costFor(try play(for: result.playID).genre, attendanceCount: result.audience)
             result.volumeCredits = volumeCreditsFor(try play(for: result.playID).genre, attendanceCount: result.audience)

--- a/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -21,6 +21,7 @@ class StatementPrinter {
         func enrich(_ performance: Performance) throws -> Performance {
             var result = performance
             result.charge = .init(playName: try play(for: result.playID).name)
+            
             result.play = try play(for: result.playID)
             result.cost = try costFor(try play(for: result.playID).genre, attendanceCount: result.audience)
             result.volumeCredits = volumeCreditsFor(try play(for: result.playID).genre, attendanceCount: result.audience)
@@ -76,7 +77,7 @@ class StatementPrinter {
         
         for performance in data.performances {
             // print line for this order
-            result += "  \(performance.play!.name): \(usd(amount: performance.cost!)) (\(performance.audience) seats)\n"
+            result += "  \(performance.charge.playName): \(usd(amount: performance.cost!)) (\(performance.audience) seats)\n"
         }
         
         result += "Amount owed is \(usd(amount: data.totalAmount))\n"


### PR DESCRIPTION
### TL;DR

This pull request includes a refactor of the `Performance` struct in the Theatrical Players Refactoring Kata with the addition of a `PerformanceCharge` struct.

### What changed?

A new struct, `PerformanceCharge`, has been introduced replacing a previously used `Play` variable. The `Performance` struct has been updated to fit this new model. The `StatementPrinter` has been updated to make use of the `charge.playName` instead of `play.name`.

### How to test?

Test the changes by running the Theatrical Players Refactoring Kata tests to ensure that the refactor does not impact the desired outputs.

### Why make this change?

This change aims to simplify Performance's use of Play by replacing it with a less complex structure, as well as improving the readability and maintainability of the code.

---

Create `PerformanceCharge` with play name. Migrate play name from `Performance.play`

Use `PerformanceCharge.playName`, from `Performance` instead of it's `Play`, to create plain text statement.

Remove `Play` from `Performance