### PR TITLE
add performance cost to `PerformanceCharge

### DIFF
--- a/Theatrical-Players-Refactoring-Kata/Performance.swift
+++ b/Theatrical-Players-Refactoring-Kata/Performance.swift
@@ -9,7 +9,10 @@ struct Performance {
     init(
         playID: String,
         audience: Int,
-        charge: PerformanceCharge = PerformanceCharge(playName: "Placeholder", cost: 0),
+        charge: PerformanceCharge = PerformanceCharge(
+            playName: "Placeholder",
+            cost: 0,
+            volumeCredits: 0),
         volumeCredits: Int? = nil
     ) {
         self.playID = playID
@@ -22,4 +25,5 @@ struct Performance {
 struct PerformanceCharge {
     let playName: String
     let cost: Int
+    let volumeCredits: Int
 }

--- a/Theatrical-Players-Refactoring-Kata/Performance.swift
+++ b/Theatrical-Players-Refactoring-Kata/Performance.swift
@@ -7,7 +7,7 @@ struct Performance {
     var cost: Int?
     var volumeCredits: Int?
     
-    init(playID: String, audience: Int, charge: PerformanceCharge = .init(playName: "Placeholder"), play: Play? = nil, cost: Int? = nil, volumeCredits: Int? = nil) {
+    init(playID: String, audience: Int, charge: PerformanceCharge = .init(playName: "Placeholder", cost: 0), play: Play? = nil, cost: Int? = nil, volumeCredits: Int? = nil) {
         self.playID = playID
         self.audience = audience
         self.charge = charge
@@ -18,4 +18,5 @@ struct Performance {
 
 struct PerformanceCharge {
     let playName: String
+    let cost: Int
 }

--- a/Theatrical-Players-Refactoring-Kata/Performance.swift
+++ b/Theatrical-Players-Refactoring-Kata/Performance.swift
@@ -4,14 +4,17 @@ struct Performance {
     
     var charge: PerformanceCharge
     
-    var cost: Int?
     var volumeCredits: Int?
     
-    init(playID: String, audience: Int, charge: PerformanceCharge = .init(playName: "Placeholder", cost: 0), play: Play? = nil, cost: Int? = nil, volumeCredits: Int? = nil) {
+    init(
+        playID: String,
+        audience: Int,
+        charge: PerformanceCharge = PerformanceCharge(playName: "Placeholder", cost: 0),
+        volumeCredits: Int? = nil
+    ) {
         self.playID = playID
         self.audience = audience
         self.charge = charge
-        self.cost = cost
         self.volumeCredits = volumeCredits
     }
 }

--- a/Theatrical-Players-Refactoring-Kata/Performance.swift
+++ b/Theatrical-Players-Refactoring-Kata/Performance.swift
@@ -4,21 +4,17 @@ struct Performance {
     
     var charge: PerformanceCharge
     
-    var volumeCredits: Int?
-    
     init(
         playID: String,
         audience: Int,
         charge: PerformanceCharge = PerformanceCharge(
             playName: "Placeholder",
             cost: 0,
-            volumeCredits: 0),
-        volumeCredits: Int? = nil
+            volumeCredits: 0)
     ) {
         self.playID = playID
         self.audience = audience
         self.charge = charge
-        self.volumeCredits = volumeCredits
     }
 }
 

--- a/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -15,7 +15,7 @@ class StatementPrinter {
             customer: invoice.customer,
             performances: try invoice.performances.map(enrich),
             totalAmount: totalOf(try invoice.performances.map(enrich).map { $0.charge.cost }),
-            totalVolumeCredits: totalOf(try invoice.performances.map(enrich).map { $0.volumeCredits! })
+            totalVolumeCredits: totalOf(try invoice.performances.map(enrich).map { $0.charge.volumeCredits })
         )
         
         func enrich(_ performance: Performance) throws -> Performance {

--- a/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -20,7 +20,10 @@ class StatementPrinter {
         
         func enrich(_ performance: Performance) throws -> Performance {
             var result = performance
-            result.charge = .init(playName: try play(for: result.playID).name)
+            result.charge = .init(
+                playName: try play(for: result.playID).name,
+                cost: try costFor(try play(for: result.playID).genre, attendanceCount: result.audience)
+            )
             
             result.cost = try costFor(try play(for: result.playID).genre, attendanceCount: result.audience)
             result.volumeCredits = volumeCreditsFor(try play(for: result.playID).genre, attendanceCount: result.audience)

--- a/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -79,7 +79,7 @@ class StatementPrinter {
         
         for performance in data.performances {
             // print line for this order
-            result += "  \(performance.charge.playName): \(usd(amount: performance.cost!)) (\(performance.audience) seats)\n"
+            result += "  \(performance.charge.playName): \(usd(amount: performance.charge.cost)) (\(performance.audience) seats)\n"
         }
         
         result += "Amount owed is \(usd(amount: data.totalAmount))\n"

--- a/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -14,7 +14,7 @@ class StatementPrinter {
         return StatementData(
             customer: invoice.customer,
             performances: try invoice.performances.map(enrich),
-            totalAmount: totalOf(try invoice.performances.map(enrich).map { $0.cost! }),
+            totalAmount: totalOf(try invoice.performances.map(enrich).map { $0.charge.cost }),
             totalVolumeCredits: totalOf(try invoice.performances.map(enrich).map { $0.volumeCredits! })
         )
         
@@ -25,7 +25,6 @@ class StatementPrinter {
                 cost: try costFor(try play(for: result.playID).genre, attendanceCount: result.audience)
             )
             
-            result.cost = try costFor(try play(for: result.playID).genre, attendanceCount: result.audience)
             result.volumeCredits = volumeCreditsFor(try play(for: result.playID).genre, attendanceCount: result.audience)
             return result
         }

--- a/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -28,7 +28,6 @@ class StatementPrinter {
                 volumeCredits: volumeCreditsFor(try play(for: result.playID).genre, attendanceCount: result.audience)
             )
             
-            result.volumeCredits = volumeCreditsFor(try play(for: result.playID).genre, attendanceCount: result.audience)
             return result
         }
         

--- a/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -22,7 +22,10 @@ class StatementPrinter {
             var result = performance
             result.charge = .init(
                 playName: try play(for: result.playID).name,
-                cost: try costFor(try play(for: result.playID).genre, attendanceCount: result.audience)
+                cost: try costFor(
+                    try play(for: result.playID).genre,
+                    attendanceCount: result.audience),
+                volumeCredits: volumeCreditsFor(try play(for: result.playID).genre, attendanceCount: result.audience)
             )
             
             result.volumeCredits = volumeCreditsFor(try play(for: result.playID).genre, attendanceCount: result.audience)


### PR DESCRIPTION
add performance cost to `PerformanceCharge

Use `PerformanceCharge.cost` in plain text generator, removing force unwrap

Use `PerformanceCharge.cost` in `StatementData` instead of force unwraped `Performancee.cost`

Remove cost from `Performance`

Add `volumeCredits` to `PerformanceCharge`

Use `PerformanceCharge.volumeCredits` in `StatementData` creation, removing force unwrap

Remove `volumeCredits` from `Performance`