### PR TITLE
Add PerformanceCharge struct and refactor StatementPrinter class to migrate charge totals responsibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,94 @@
+# Created by https://www.gitignore.io/api/swift,xcode
+
+### Swift ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
+#
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+# End of https://www.gitignore.io/api/swift,xcode

--- a/Theatrical-Players-Refactoring-Kata.xcodeproj/project.pbxproj
+++ b/Theatrical-Players-Refactoring-Kata.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		104F7D91232830EF00665957 /* Performance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 104F7D90232830EF00665957 /* Performance.swift */; };
 		104F7D932328312700665957 /* Invoice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 104F7D922328312600665957 /* Invoice.swift */; };
 		104F7D95232831E000665957 /* StatementPrinter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 104F7D94232831E000665957 /* StatementPrinter.swift */; };
+		8C46E75B2BFBD99700127562 /* PerformanceCharge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C46E75A2BFBD99700127562 /* PerformanceCharge.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -37,6 +38,7 @@
 		104F7D90232830EF00665957 /* Performance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Performance.swift; sourceTree = "<group>"; };
 		104F7D922328312600665957 /* Invoice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Invoice.swift; sourceTree = "<group>"; };
 		104F7D94232831E000665957 /* StatementPrinter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatementPrinter.swift; sourceTree = "<group>"; };
+		8C46E75A2BFBD99700127562 /* PerformanceCharge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceCharge.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -83,6 +85,7 @@
 				104F7D7823282F2900665957 /* Info.plist */,
 				104F7D8E2328305A00665957 /* Play.swift */,
 				104F7D90232830EF00665957 /* Performance.swift */,
+				8C46E75A2BFBD99700127562 /* PerformanceCharge.swift */,
 				104F7D922328312600665957 /* Invoice.swift */,
 				104F7D94232831E000665957 /* StatementPrinter.swift */,
 			);
@@ -208,6 +211,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				104F7D91232830EF00665957 /* Performance.swift in Sources */,
+				8C46E75B2BFBD99700127562 /* PerformanceCharge.swift in Sources */,
 				104F7D932328312700665957 /* Invoice.swift in Sources */,
 				104F7D95232831E000665957 /* StatementPrinter.swift in Sources */,
 				104F7D8F2328305A00665957 /* Play.swift in Sources */,

--- a/Theatrical-Players-Refactoring-Kata/Performance.swift
+++ b/Theatrical-Players-Refactoring-Kata/Performance.swift
@@ -2,10 +2,3 @@ struct Performance {
     let playID: String
     let audience: Int
 }
-
-struct PerformanceCharge {
-    let playName: String
-    let cost: Int
-    let volumeCredits: Int
-    let attendanceCount: Int
-}

--- a/Theatrical-Players-Refactoring-Kata/Performance.swift
+++ b/Theatrical-Players-Refactoring-Kata/Performance.swift
@@ -10,7 +10,8 @@ struct Performance {
         charge: PerformanceCharge = PerformanceCharge(
             playName: "Placeholder",
             cost: 0,
-            volumeCredits: 0)
+            volumeCredits: 0,
+            attendanceCount: 0)
     ) {
         self.playID = playID
         self.audience = audience
@@ -22,4 +23,5 @@ struct PerformanceCharge {
     let playName: String
     let cost: Int
     let volumeCredits: Int
+    let attendanceCount: Int
 }

--- a/Theatrical-Players-Refactoring-Kata/Performance.swift
+++ b/Theatrical-Players-Refactoring-Kata/Performance.swift
@@ -1,22 +1,6 @@
 struct Performance {
     let playID: String
     let audience: Int
-    
-    var charge: PerformanceCharge
-    
-    init(
-        playID: String,
-        audience: Int,
-        charge: PerformanceCharge = PerformanceCharge(
-            playName: "Placeholder",
-            cost: 0,
-            volumeCredits: 0,
-            attendanceCount: 0)
-    ) {
-        self.playID = playID
-        self.audience = audience
-        self.charge = charge
-    }
 }
 
 struct PerformanceCharge {

--- a/Theatrical-Players-Refactoring-Kata/PerformanceCharge.swift
+++ b/Theatrical-Players-Refactoring-Kata/PerformanceCharge.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct PerformanceCharge {
+    let playName: String
+    let cost: Int
+    let volumeCredits: Int
+    let attendanceCount: Int
+}

--- a/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -31,7 +31,8 @@ class StatementPrinter {
                 cost: try costFor(
                     try play(for: performance.playID).genre,
                     attendanceCount: performance.audience),
-                volumeCredits: volumeCreditsFor(try play(for: performance.playID).genre, attendanceCount: performance.audience)
+                volumeCredits: volumeCreditsFor(try play(for: performance.playID).genre, attendanceCount: performance.audience), 
+                attendanceCount: performance.audience
             )
         }
         

--- a/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -1,7 +1,7 @@
 class StatementPrinter {
     struct StatementData {
         let customer: String
-        let performances: [Performance]
+        let performanceCharges: [PerformanceCharge]
         let totalAmount: Int
         let totalVolumeCredits: Int
     }
@@ -13,17 +13,10 @@ class StatementPrinter {
     private func generateStatementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>) throws -> StatementData {
         return StatementData(
             customer: invoice.customer,
-            performances: try invoice.performances.map(enrich),
-            totalAmount: totalOf(try invoice.performances.map(enrich).map { $0.charge.cost }),
-            totalVolumeCredits: totalOf(try invoice.performances.map(enrich).map { $0.charge.volumeCredits })
+            performanceCharges: try invoice.performances.map(charge),
+            totalAmount: totalOf(try invoice.performances.map(charge).map { $0.cost }),
+            totalVolumeCredits: totalOf(try invoice.performances.map(charge).map { $0.volumeCredits })
         )
-        
-        func enrich(_ performance: Performance) throws -> Performance {
-            var result = performance
-            result.charge = try charge(result)
-            
-            return result
-        }
         
         func charge(_ performance: Performance) throws -> PerformanceCharge {
             .init(
@@ -83,9 +76,9 @@ class StatementPrinter {
     private func renderPlainText(_ data: StatementData) throws -> String {
         var result = "Statement for \(data.customer)\n"
         
-        for performance in data.performances {
+        for charge in data.performanceCharges {
             // print line for this order
-            result += "  \(performance.charge.playName): \(usd(amount: performance.charge.cost)) (\(performance.audience) seats)\n"
+            result += "  \(charge.playName): \(usd(amount: charge.cost)) (\(charge.attendanceCount) seats)\n"
         }
         
         result += "Amount owed is \(usd(amount: data.totalAmount))\n"

--- a/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -20,15 +20,19 @@ class StatementPrinter {
         
         func enrich(_ performance: Performance) throws -> Performance {
             var result = performance
-            result.charge = .init(
-                playName: try play(for: result.playID).name,
-                cost: try costFor(
-                    try play(for: result.playID).genre,
-                    attendanceCount: result.audience),
-                volumeCredits: volumeCreditsFor(try play(for: result.playID).genre, attendanceCount: result.audience)
-            )
+            result.charge = try charge(result)
             
             return result
+        }
+        
+        func charge(_ performance: Performance) throws -> PerformanceCharge {
+            .init(
+                playName: try play(for: performance.playID).name,
+                cost: try costFor(
+                    try play(for: performance.playID).genre,
+                    attendanceCount: performance.audience),
+                volumeCredits: volumeCreditsFor(try play(for: performance.playID).genre, attendanceCount: performance.audience)
+            )
         }
         
         func play(for playId: String) throws -> Play {


### PR DESCRIPTION
### TL;DR
Added a new `PerformanceCharge` struct and refactored the `StatementPrinter` class.

### What changed?
The pull request includes the addition of the `PerformanceCharge` struct with attributes for play name, cost, volume credits, and attendance count. The `StatementPrinter` class was refactored to use `PerformanceCharge` instead of `Performance` for calculations.

### How to test?
Test the application with different performance scenarios and check if the statement prints the correct details.

### Why make this change?
The change was made to improve code readability and decouple helper methods in the `StatementPrinter` class.

---

extract method to create `PerformanceCharge` from `Perfromance`

Add `attendanceCount` to `PerformanceCharge` in preparation of replacing `Performance` in the places it is used outside the scope of it's responsibility

Replace `Performance` with `PerformanceCharge`

Add gitignore

Move `PerformanceCharge` to it's own file