### PR TITLE
Add HTML printing

### DIFF
--- a/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
@@ -40,7 +40,7 @@ func generateStatementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>
             }
             result += 300 * attendanceCount
         case .unknown:
-            throw UnknownTypeError.unknownTypeError("unknown type: \(genre)")
+            throw UnknownTypeError.unknownTypeError("new play")
         }
         
         return result

--- a/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
@@ -11,8 +11,12 @@ func generateStatementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>
             playName: try play(for: performance.playID).name,
             cost: try costFor(
                 try play(for: performance.playID).genre,
-                attendanceCount: performance.audience),
-            volumeCredits: volumeCreditsFor(try play(for: performance.playID).genre, attendanceCount: performance.audience),
+                attendanceCount: performance.audience
+            ),
+            volumeCredits: volumeCreditsFor(
+                try play(for: performance.playID).genre,
+                attendanceCount: performance.audience
+            ),
             attendanceCount: performance.audience
         )
     }

--- a/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
@@ -2,8 +2,8 @@ func generateStatementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>
     return StatementData(
         customer: invoice.customer,
         performanceCharges: try invoice.performances.map(charge),
-        totalAmount: totalOf(try invoice.performances.map(charge).map { $0.cost }),
-        totalVolumeCredits: totalOf(try invoice.performances.map(charge).map { $0.volumeCredits })
+        totalAmount: try invoice.performances.map(charge).map { $0.cost }.sum,
+        totalVolumeCredits: try invoice.performances.map(charge).map { $0.volumeCredits }.sum
     )
     
     func charge(_ performance: Performance) throws -> PerformanceCharge {
@@ -55,8 +55,10 @@ func generateStatementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>
         }
         return result
     }
-    
-    func totalOf(_ amounts: [Int]) -> Int {
-        amounts.reduce(0) { $0 + $1 }
+}
+
+private extension Array where Element == Int {
+    var sum: Int {
+        self.reduce(0) { $0 + $1 }
     }
 }

--- a/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -15,12 +15,13 @@ class StatementPrinter {
         result += "You earned \(data.totalVolumeCredits) credits\n"
         return result
         
-        func usd(amount: Int) -> String {
-            let frmt = NumberFormatter()
-            frmt.numberStyle = .currency
-            frmt.locale = Locale(identifier: "en_US")
-            return frmt.string(for: NSNumber(value: Double(amount / 100)))!
-        }
+    }
+    
+    private func usd(amount: Int) -> String {
+        let frmt = NumberFormatter()
+        frmt.numberStyle = .currency
+        frmt.locale = Locale(identifier: "en_US")
+        return frmt.string(for: NSNumber(value: Double(amount / 100)))!
     }
 }
 

--- a/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -1,13 +1,13 @@
 class StatementPrinter {
     func generateStatement(_ invoice: Invoice, _ plays: Dictionary<String, Play>) throws -> String {
-        try renderPlainText(generateStatementData(invoice, plays))
+        renderPlainText(try generateStatementData(invoice, plays))
     }
     
     func generateStatementHTML(_ invoice: Invoice, _ plays: Dictionary<String, Play>) throws -> String {
-        try renderHTML(generateStatementData(invoice, plays))
+        renderHTML(try generateStatementData(invoice, plays))
     }
     
-    private func renderPlainText(_ data: StatementData) throws -> String {
+    private func renderPlainText(_ data: StatementData) -> String {
         var result = "Statement for \(data.customer)\n"
         
         for charge in data.performanceCharges {
@@ -20,7 +20,7 @@ class StatementPrinter {
         return result
     }
     
-    private func renderHTML(_ data: StatementData) throws -> String {
+    private func renderHTML(_ data: StatementData) -> String {
         var result = "<h1>Statement for \(data.customer)</h1>\n"
         result += "<table>\n"
         result += "<tr><th>play</th><th>seats</th><th>cost</th></tr>"

--- a/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -1,6 +1,10 @@
 class StatementPrinter {
     func generateStatement(_ invoice: Invoice, _ plays: Dictionary<String, Play>) throws -> String {
-        return try renderPlainText(generateStatementData(invoice, plays))
+        try renderPlainText(generateStatementData(invoice, plays))
+    }
+    
+    func generateStatementHTML(_ invoice: Invoice, _ plays: Dictionary<String, Play>) throws -> String {
+        try renderHTML(generateStatementData(invoice, plays))
     }
     
     private func renderPlainText(_ data: StatementData) throws -> String {
@@ -14,7 +18,20 @@ class StatementPrinter {
         result += "Amount owed is \(usd(amount: data.totalAmount))\n"
         result += "You earned \(data.totalVolumeCredits) credits\n"
         return result
-        
+    }
+    
+    private func renderHTML(_ data: StatementData) throws -> String {
+        var result = "<h1>Statement for \(data.customer)</h1>\n"
+        result += "<table>\n"
+        result += "<tr><th>play</th><th>seats</th><th>cost</th></tr>"
+        for perf in data.performanceCharges {
+            result += "<tr><td>\(perf.playName)</td><td>\(perf.attendanceCount)</td>"
+            result += "<td>\(usd(amount: perf.cost))</td></tr>\n"
+        }
+        result += "</table>\n"
+        result += "<p>Amount owed is <em>\(usd(amount: data.totalAmount))</em></p>\n"
+        result += "<p>You earned <em>\(data.totalVolumeCredits)</em> credits</p>\n"
+        return result
     }
     
     private func usd(amount: Int) -> String {

--- a/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 class StatementPrinterTests: XCTestCase {
     func test_generateStatement_producesStatmentForKnownPlays() throws {
-        let expected = """
+        let expectedStatementPlainText = """
             Statement for BigCo
               Hamlet: $650.00 (55 seats)
               As You Like It: $580.00 (35 seats)
@@ -13,21 +13,20 @@ class StatementPrinterTests: XCTestCase {
             You earned 47 credits
 
             """
+        let sut = StatementPrinter()
         
-        let statementPrinter = StatementPrinter()
-        let result = try statementPrinter.generateStatement(invoiceWithKnownPlays(), knownPlays())
+        let result = try sut.generateStatement(invoiceWithKnownPlays(), knownPlays())
         
-        XCTAssertEqual(result, expected)
+        XCTAssertEqual(result, expectedStatementPlainText)
     }
     
     func test_generateStatement_throwsErrorOnNewPlayTypes() {
-        let statementPrinter = StatementPrinter()
-        
+        let sut = StatementPrinter()
         let expectedError = UnknownTypeError.unknownTypeError("new play")
-        
+
         var unknownPlayError: UnknownTypeError?
         do {
-            let _ = try statementPrinter.generateStatement(invoiceWithNewPlay(), newPlay())
+            let _ = try sut.generateStatement(invoiceWithNewPlay(), newPlay())
         } catch let error as UnknownTypeError {
             unknownPlayError = error
         } catch {
@@ -38,12 +37,12 @@ class StatementPrinterTests: XCTestCase {
     }
     
     func test_generateStatement_throwsErrorOnUknownPlay() {
-        let statementPrinter = StatementPrinter()
+        let sut = StatementPrinter()
         let expectedError = UnknownTypeError.unknownTypeError("unknown play")
         
         var unknownPlayError: UnknownTypeError?
         do {
-            let _ = try statementPrinter.generateStatement(invoiceWithKnownPlays(), missingPlay())
+            let _ = try sut.generateStatement(invoiceWithKnownPlays(), missingPlay())
         } catch let error as UnknownTypeError {
             unknownPlayError = error
         } catch {
@@ -54,7 +53,7 @@ class StatementPrinterTests: XCTestCase {
     }
     
     func test_generateStatementHTML_producesHTMLFormattedStatementForKnownPlays() throws {
-        let expected = """
+        let expectedStatementHTML = """
             <h1>Statement for BigCo</h1>
             <table>
             <tr><th>play</th><th>seats</th><th>cost</th></tr><tr><td>Hamlet</td><td>55</td><td>$650.00</td></tr>
@@ -66,9 +65,10 @@ class StatementPrinterTests: XCTestCase {
             
             """
         
-        let statementPrinter = StatementPrinter()
-        let result = try statementPrinter.generateStatementHTML(invoiceWithKnownPlays(), knownPlays())
-        XCTAssertEqual(result, expected)
+        let sut = StatementPrinter()
+        let result = try sut.generateStatementHTML(invoiceWithKnownPlays(), knownPlays())
+        
+        XCTAssertEqual(result, expectedStatementHTML)
     }
 }
 

--- a/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
@@ -29,7 +29,19 @@ class StatementPrinterTests: XCTestCase {
         )
         
         let statementPrinter = StatementPrinter()
-        XCTAssertThrowsError(try statementPrinter.generateStatement(invoice, newPlay()))
+        
+        let expectedError = UnknownTypeError.unknownTypeError("new play")
+        
+        var unknownPlayError: UnknownTypeError?
+        do {
+            let _ = try statementPrinter.generateStatement(invoice, newPlay())
+        } catch let error as UnknownTypeError {
+            unknownPlayError = error
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        
+        XCTAssertEqual(unknownPlayError, expectedError)
     }
     
     func test_generateStatement_throwsErrorOnUknownPlay() {

--- a/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
@@ -4,7 +4,6 @@ import XCTest
 
 class StatementPrinterTests: XCTestCase {
     func test_generateStatement_producesStatmentForKnownPlays() throws {
-        
         let expected = """
             Statement for BigCo
               Hamlet: $650.00 (55 seats)
@@ -77,5 +76,37 @@ class StatementPrinterTests: XCTestCase {
         }
         
         XCTAssertEqual(unknownPlayError, expectedError)
+    }
+    
+    func test_generateStatementHTML_producesHTMLFormattedStatementForKnownPlays() throws {
+        let expected = """
+            <h1>Statement for BigCo</h1>
+            <table>
+            <tr><th>play</th><th>seats</th><th>cost</th></tr><tr><td>Hamlet</td><td>55</td><td>$650.00</td></tr>
+            <tr><td>As You Like It</td><td>35</td><td>$580.00</td></tr>
+            <tr><td>Othello</td><td>40</td><td>$500.00</td></tr>
+            </table>
+            <p>Amount owed is <em>$1,730.00</em></p>
+            <p>You earned <em>47</em> credits</p>
+            
+            """
+        
+        let plays = [
+            "hamlet": Play(name: "Hamlet", genre: .tragedy),
+            "as-like": Play(name: "As You Like It", genre: .comedy),
+            "othello": Play(name: "Othello", genre: .tragedy)
+        ]
+        
+        let invoice = Invoice(
+            customer: "BigCo", performances: [
+                Performance(playID: "hamlet", audience: 55),
+                Performance(playID: "as-like", audience: 35),
+                Performance(playID: "othello", audience: 40)
+            ]
+        )
+        
+        let statementPrinter = StatementPrinter()
+        let result = try statementPrinter.generateStatementHTML(invoice, plays)
+        XCTAssertEqual(result, expected)
     }
 }

--- a/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
@@ -14,12 +14,6 @@ class StatementPrinterTests: XCTestCase {
 
             """
         
-        let plays = [
-            "hamlet": Play(name: "Hamlet", genre: .tragedy),
-            "as-like": Play(name: "As You Like It", genre: .comedy),
-            "othello": Play(name: "Othello", genre: .tragedy)
-        ]
-        
         let invoice = Invoice(
             customer: "BigCo", performances: [
                 Performance(playID: "hamlet", audience: 55),
@@ -29,7 +23,7 @@ class StatementPrinterTests: XCTestCase {
         )
         
         let statementPrinter = StatementPrinter()
-        let result = try statementPrinter.generateStatement(invoice, plays)
+        let result = try statementPrinter.generateStatement(invoice, knownPlays())
         
         XCTAssertEqual(result, expected)
     }
@@ -91,12 +85,6 @@ class StatementPrinterTests: XCTestCase {
             
             """
         
-        let plays = [
-            "hamlet": Play(name: "Hamlet", genre: .tragedy),
-            "as-like": Play(name: "As You Like It", genre: .comedy),
-            "othello": Play(name: "Othello", genre: .tragedy)
-        ]
-        
         let invoice = Invoice(
             customer: "BigCo", performances: [
                 Performance(playID: "hamlet", audience: 55),
@@ -106,7 +94,17 @@ class StatementPrinterTests: XCTestCase {
         )
         
         let statementPrinter = StatementPrinter()
-        let result = try statementPrinter.generateStatementHTML(invoice, plays)
+        let result = try statementPrinter.generateStatementHTML(invoice, knownPlays())
         XCTAssertEqual(result, expected)
+    }
+}
+
+extension StatementPrinterTests {
+    func knownPlays() -> Dictionary<String, Play> {
+        [
+            "hamlet": Play(name: "Hamlet", genre: .tragedy),
+            "as-like": Play(name: "As You Like It", genre: .comedy),
+            "othello": Play(name: "Othello", genre: .tragedy)
+        ]
     }
 }

--- a/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
@@ -21,20 +21,13 @@ class StatementPrinterTests: XCTestCase {
     }
     
     func test_generateStatement_throwsErrorOnNewPlayTypes() {
-        let invoice = Invoice(
-            customer: "BigCo", performances: [
-                Performance(playID: "henry-v", audience: 53),
-                Performance(playID: "as-like", audience: 55)
-            ]
-        )
-        
         let statementPrinter = StatementPrinter()
         
         let expectedError = UnknownTypeError.unknownTypeError("new play")
         
         var unknownPlayError: UnknownTypeError?
         do {
-            let _ = try statementPrinter.generateStatement(invoice, newPlay())
+            let _ = try statementPrinter.generateStatement(invoiceWithNewPlay(), newPlay())
         } catch let error as UnknownTypeError {
             unknownPlayError = error
         } catch {
@@ -105,6 +98,16 @@ extension StatementPrinterTests {
                 Performance(playID: "hamlet", audience: 55),
                 Performance(playID: "as-like", audience: 35),
                 Performance(playID: "othello", audience: 40)
+            ]
+        )
+    }
+    
+    func invoiceWithNewPlay() -> Invoice {
+        Invoice(
+            customer: "BigCo", 
+            performances: [
+                Performance(playID: "henry-v", audience: 53),
+                Performance(playID: "as-like", audience: 55)
             ]
         )
     }

--- a/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
@@ -21,11 +21,6 @@ class StatementPrinterTests: XCTestCase {
     }
     
     func test_generateStatement_throwsErrorOnNewPlayTypes() {
-        let plays = [
-            "henry-v": Play(name: "Henry V", genre: .unknown),
-            "as-like": Play(name: "As You Like It", genre: .unknown)
-        ]
-        
         let invoice = Invoice(
             customer: "BigCo", performances: [
                 Performance(playID: "henry-v", audience: 53),
@@ -34,7 +29,7 @@ class StatementPrinterTests: XCTestCase {
         )
         
         let statementPrinter = StatementPrinter()
-        XCTAssertThrowsError(try statementPrinter.generateStatement(invoice, plays))        
+        XCTAssertThrowsError(try statementPrinter.generateStatement(invoice, newPlay()))
     }
     
     func test_generateStatement_throwsErrorOnUknownPlay() {
@@ -82,6 +77,13 @@ extension StatementPrinterTests {
             "hamlet": Play(name: "Hamlet", genre: .tragedy),
             "as-like": Play(name: "As You Like It", genre: .comedy),
             "othello": Play(name: "Othello", genre: .tragedy)
+        ]
+    }
+    
+    func newPlay() -> Dictionary<String, Play> {
+        [
+            "henry-v": Play(name: "Henry V", genre: .unknown),
+            "as-like": Play(name: "As You Like It", genre: .unknown)
         ]
     }
     

--- a/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
@@ -14,16 +14,8 @@ class StatementPrinterTests: XCTestCase {
 
             """
         
-        let invoice = Invoice(
-            customer: "BigCo", performances: [
-                Performance(playID: "hamlet", audience: 55),
-                Performance(playID: "as-like", audience: 35),
-                Performance(playID: "othello", audience: 40)
-            ]
-        )
-        
         let statementPrinter = StatementPrinter()
-        let result = try statementPrinter.generateStatement(invoice, knownPlays())
+        let result = try statementPrinter.generateStatement(invoiceWithKnownPlays(), knownPlays())
         
         XCTAssertEqual(result, expected)
     }
@@ -50,19 +42,12 @@ class StatementPrinterTests: XCTestCase {
             "hamlet": Play(name: "Hamlet", genre: .tragedy),
             "as-like": Play(name: "As You Like It", genre: .tragedy)
         ]
-        let invoice = Invoice(
-            customer: "BigCo", performances: [
-                Performance(playID: "hamlet", audience: 55),
-                Performance(playID: "as-like", audience: 35),
-                Performance(playID: "othello", audience: 40)
-            ]
-        )
         let statementPrinter = StatementPrinter()
         let expectedError = UnknownTypeError.unknownTypeError("unknown play")
         
         var unknownPlayError: UnknownTypeError?
         do {
-            let _ = try statementPrinter.generateStatement(invoice, plays)
+            let _ = try statementPrinter.generateStatement(invoiceWithKnownPlays(), plays)
         } catch let error as UnknownTypeError {
             unknownPlayError = error
         } catch {
@@ -85,16 +70,8 @@ class StatementPrinterTests: XCTestCase {
             
             """
         
-        let invoice = Invoice(
-            customer: "BigCo", performances: [
-                Performance(playID: "hamlet", audience: 55),
-                Performance(playID: "as-like", audience: 35),
-                Performance(playID: "othello", audience: 40)
-            ]
-        )
-        
         let statementPrinter = StatementPrinter()
-        let result = try statementPrinter.generateStatementHTML(invoice, knownPlays())
+        let result = try statementPrinter.generateStatementHTML(invoiceWithKnownPlays(), knownPlays())
         XCTAssertEqual(result, expected)
     }
 }
@@ -106,5 +83,15 @@ extension StatementPrinterTests {
             "as-like": Play(name: "As You Like It", genre: .comedy),
             "othello": Play(name: "Othello", genre: .tragedy)
         ]
+    }
+    
+    func invoiceWithKnownPlays() -> Invoice {
+        Invoice(
+            customer: "BigCo", performances: [
+                Performance(playID: "hamlet", audience: 55),
+                Performance(playID: "as-like", audience: 35),
+                Performance(playID: "othello", audience: 40)
+            ]
+        )
     }
 }

--- a/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
@@ -38,16 +38,12 @@ class StatementPrinterTests: XCTestCase {
     }
     
     func test_generateStatement_throwsErrorOnUknownPlay() {
-        let plays = [
-            "hamlet": Play(name: "Hamlet", genre: .tragedy),
-            "as-like": Play(name: "As You Like It", genre: .tragedy)
-        ]
         let statementPrinter = StatementPrinter()
         let expectedError = UnknownTypeError.unknownTypeError("unknown play")
         
         var unknownPlayError: UnknownTypeError?
         do {
-            let _ = try statementPrinter.generateStatement(invoiceWithKnownPlays(), plays)
+            let _ = try statementPrinter.generateStatement(invoiceWithKnownPlays(), missingPlay())
         } catch let error as UnknownTypeError {
             unknownPlayError = error
         } catch {
@@ -89,6 +85,13 @@ extension StatementPrinterTests {
         [
             "henry-v": Play(name: "Henry V", genre: .unknown),
             "as-like": Play(name: "As You Like It", genre: .unknown)
+        ]
+    }
+    
+    func missingPlay() -> Dictionary<String, Play> {
+        [
+            "hamlet": Play(name: "Hamlet", genre: .tragedy),
+            "as-like": Play(name: "As You Like It", genre: .tragedy)
         ]
     }
     


### PR DESCRIPTION
### TL;DR
Refactored the `StatementDataProvider` and `StatementPrinter` classes.

### What changed?
- Refactored code in `StatementDataProvider` to use a `sum` extension on `Array` for calculating totals.
- Updated `StatementPrinter` to provide methods for generating plain text and HTML statements.

### How to test?
- Run tests to ensure plain text and HTML statements are generated correctly.

### Why make this change?
The refactor improves code readability and separates concerns, making it easier to maintain and extend the functionality of the classes.

---

Move usd formatting to top level of `StatementPrinter` so that it can be shared with the html generation

`StatementPrinter.generateStatementHTML` produces html for known plays

Refactor known plays test data into helper function

Refactor test invoice data with known plays into helper function

Refactor new play test data into reusable helper method

Update new play test to use easier to understand error message for determining the cause

Refactor invoice with new play test data into a helper function for reuse

Create reusable helper function for missing play test data

improving naming and layout of tests contents

Move trys to actually failable methods

Replace `totalOf(` with array helper to sum integers

make code more readable with indentation