### PR TITLE
Add New Play

### DIFF
--- a/Theatrical-Players-Refactoring-Kata.xcodeproj/project.pbxproj
+++ b/Theatrical-Players-Refactoring-Kata.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		8C46E75D2BFBDED800127562 /* StatementDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C46E75C2BFBDED800127562 /* StatementDataProvider.swift */; };
 		8C46E75F2BFBF1E500127562 /* StatementData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C46E75E2BFBF1E500127562 /* StatementData.swift */; };
 		8C46E7632BFE3C6600127562 /* PerformanceCostProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C46E7622BFE3C6600127562 /* PerformanceCostProviderTests.swift */; };
+		8C46E7652BFE73BC00127562 /* PerformanceCostProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C46E7642BFE73BC00127562 /* PerformanceCostProvider.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -45,6 +46,7 @@
 		8C46E75C2BFBDED800127562 /* StatementDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatementDataProvider.swift; sourceTree = "<group>"; };
 		8C46E75E2BFBF1E500127562 /* StatementData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatementData.swift; sourceTree = "<group>"; };
 		8C46E7622BFE3C6600127562 /* PerformanceCostProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceCostProviderTests.swift; sourceTree = "<group>"; };
+		8C46E7642BFE73BC00127562 /* PerformanceCostProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceCostProvider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -96,6 +98,7 @@
 				104F7D94232831E000665957 /* StatementPrinter.swift */,
 				8C46E75C2BFBDED800127562 /* StatementDataProvider.swift */,
 				8C46E75E2BFBF1E500127562 /* StatementData.swift */,
+				8C46E7642BFE73BC00127562 /* PerformanceCostProvider.swift */,
 			);
 			path = "Theatrical-Players-Refactoring-Kata";
 			sourceTree = "<group>";
@@ -225,6 +228,7 @@
 				104F7D932328312700665957 /* Invoice.swift in Sources */,
 				104F7D95232831E000665957 /* StatementPrinter.swift in Sources */,
 				8C46E75F2BFBF1E500127562 /* StatementData.swift in Sources */,
+				8C46E7652BFE73BC00127562 /* PerformanceCostProvider.swift in Sources */,
 				104F7D8F2328305A00665957 /* Play.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Theatrical-Players-Refactoring-Kata.xcodeproj/project.pbxproj
+++ b/Theatrical-Players-Refactoring-Kata.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		8C46E75B2BFBD99700127562 /* PerformanceCharge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C46E75A2BFBD99700127562 /* PerformanceCharge.swift */; };
 		8C46E75D2BFBDED800127562 /* StatementDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C46E75C2BFBDED800127562 /* StatementDataProvider.swift */; };
 		8C46E75F2BFBF1E500127562 /* StatementData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C46E75E2BFBF1E500127562 /* StatementData.swift */; };
+		8C46E7632BFE3C6600127562 /* PerformanceCostProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C46E7622BFE3C6600127562 /* PerformanceCostProviderTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -43,6 +44,7 @@
 		8C46E75A2BFBD99700127562 /* PerformanceCharge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceCharge.swift; sourceTree = "<group>"; };
 		8C46E75C2BFBDED800127562 /* StatementDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatementDataProvider.swift; sourceTree = "<group>"; };
 		8C46E75E2BFBF1E500127562 /* StatementData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatementData.swift; sourceTree = "<group>"; };
+		8C46E7622BFE3C6600127562 /* PerformanceCostProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceCostProviderTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -103,6 +105,7 @@
 			children = (
 				104F7D8223282F2900665957 /* StatementPrinterTests.swift */,
 				104F7D8423282F2900665957 /* Info.plist */,
+				8C46E7622BFE3C6600127562 /* PerformanceCostProviderTests.swift */,
 			);
 			path = "Theatrical-Players-Refactoring-KataTests";
 			sourceTree = "<group>";
@@ -230,6 +233,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8C46E7632BFE3C6600127562 /* PerformanceCostProviderTests.swift in Sources */,
 				104F7D8323282F2900665957 /* StatementPrinterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Theatrical-Players-Refactoring-Kata/PerformanceCostProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/PerformanceCostProvider.swift
@@ -1,0 +1,34 @@
+protocol PerformanceCost {
+    func amountFor(attendanceCount count: Int) -> Int
+}
+
+struct PerformanceCostProvider {
+    func cost(for genre: Play.Genre) throws -> PerformanceCost {
+        switch(genre) {
+        case .tragedy:
+            return TragedyPerformanceCost()
+        case .comedy:
+            return ComedyPerformanceCost()
+        case .unknown:
+            throw UnknownTypeError.unknownTypeError("new play")
+        }
+    }
+    
+    struct TragedyPerformanceCost: PerformanceCost {
+        func amountFor(attendanceCount count: Int) -> Int {
+            let baseVolume = 30
+            let exceededBaseVolume = count > baseVolume
+            let additionalVolumeCost = exceededBaseVolume ? 1000 * (count - baseVolume) : 0
+            return 40000 + additionalVolumeCost
+        }
+    }
+    
+    struct ComedyPerformanceCost: PerformanceCost {
+        func amountFor(attendanceCount count: Int) -> Int {
+            let baseVolume = 20
+            let exceededBaseVolume = count > baseVolume
+            let additionalVolumeCost = exceededBaseVolume ? 10000 + 500 * (count - baseVolume) : 0
+            return 30000 + additionalVolumeCost + 300 * count
+        }
+    }
+}

--- a/Theatrical-Players-Refactoring-Kata/PerformanceCostProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/PerformanceCostProvider.swift
@@ -6,15 +6,17 @@ struct PerformanceCostProvider {
     func cost(for genre: Play.Genre) throws -> PerformanceCost {
         switch(genre) {
         case .tragedy:
-            return TragedyPerformanceCost()
+            return Tragedy()
         case .comedy:
-            return ComedyPerformanceCost()
+            return Comedy()
+        case .pastoral:
+            return Pastoral()
         case .unknown:
             throw UnknownTypeError.unknownTypeError("new play")
         }
     }
     
-    struct TragedyPerformanceCost: PerformanceCost {
+    struct Tragedy: PerformanceCost {
         func amountFor(attendanceCount count: Int) -> Int {
             let baseVolume = 30
             let exceededBaseVolume = count > baseVolume
@@ -23,12 +25,18 @@ struct PerformanceCostProvider {
         }
     }
     
-    struct ComedyPerformanceCost: PerformanceCost {
+    struct Comedy: PerformanceCost {
         func amountFor(attendanceCount count: Int) -> Int {
             let baseVolume = 20
             let exceededBaseVolume = count > baseVolume
             let additionalVolumeCost = exceededBaseVolume ? 10000 + 500 * (count - baseVolume) : 0
             return 30000 + additionalVolumeCost + 300 * count
+        }
+    }
+    
+    struct Pastoral: PerformanceCost {
+        func amountFor(attendanceCount count: Int) -> Int {
+            return 30
         }
     }
 }

--- a/Theatrical-Players-Refactoring-Kata/Play.swift
+++ b/Theatrical-Players-Refactoring-Kata/Play.swift
@@ -4,9 +4,10 @@ struct Play {
 }
 
 extension Play {
-    enum Genre: String {
+    enum Genre: String, CaseIterable {
         case tragedy
         case comedy
+        case pastoral
         case unknown
         
         init?(type: String) {
@@ -15,6 +16,8 @@ extension Play {
                 self = .tragedy
             case "comedy":
                 self = .comedy
+            case "pastoral":
+                self = .pastoral
             default:
                 self = .unknown
             }

--- a/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
@@ -49,10 +49,7 @@ struct PerformanceCostProvider {
         
         switch(genre) {
         case .tragedy:
-            result = 40000
-            if (attendanceCount > 30) {
-                result += 1000 * (attendanceCount - 30)
-            }
+            return TragedyPerformanceCost().costFor(attendanceCount: attendanceCount)
         case .comedy:
             result = 30000
             if (attendanceCount > 20) {
@@ -64,6 +61,15 @@ struct PerformanceCostProvider {
         }
         
         return result
+    }
+    
+    struct TragedyPerformanceCost {
+        func costFor(attendanceCount count: Int) -> Int {
+            let baseVolume = 30
+            let exceededBaseVolume = count > baseVolume
+            let additionalVolumeCost = exceededBaseVolume ? 1000 * (count - baseVolume) : 0
+            return 40000 + additionalVolumeCost
+        }
     }
 }
 

--- a/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
@@ -29,7 +29,7 @@ func generateStatementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>
     }
     
     func costFor(_ genre: Play.Genre, attendanceCount: Int) throws -> Int {
-        try PerformanceCostProvider().costFor(genre, attendanceCount: attendanceCount)
+        try PerformanceCostProvider().cost(for: genre).costFor(attendanceCount: attendanceCount)
     }
     
     func volumeCreditsFor(_ genre: Play.Genre, attendanceCount: Int) -> Int {
@@ -41,6 +41,10 @@ func generateStatementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>
         }
         return result
     }
+}
+
+protocol PerformanceCost {
+    func costFor(attendanceCount count: Int) -> Int
 }
 
 struct PerformanceCostProvider {
@@ -55,7 +59,18 @@ struct PerformanceCostProvider {
         }
     }
     
-    struct TragedyPerformanceCost {
+    func cost(for genre: Play.Genre) throws -> PerformanceCost {
+        switch(genre) {
+        case .tragedy:
+            return TragedyPerformanceCost()
+        case .comedy:
+            return ComedyPerformanceCost()
+        case .unknown:
+            throw UnknownTypeError.unknownTypeError("new play")
+        }
+    }
+    
+    struct TragedyPerformanceCost: PerformanceCost {
         func costFor(attendanceCount count: Int) -> Int {
             let baseVolume = 30
             let exceededBaseVolume = count > baseVolume
@@ -64,7 +79,7 @@ struct PerformanceCostProvider {
         }
     }
     
-    struct ComedyPerformanceCost {
+    struct ComedyPerformanceCost: PerformanceCost {
         func costFor(attendanceCount count: Int) -> Int {
             let baseVolume = 20
             let exceededBaseVolume = count > baseVolume

--- a/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
@@ -48,17 +48,6 @@ protocol PerformanceCost {
 }
 
 struct PerformanceCostProvider {
-    func costFor(_ genre: Play.Genre, attendanceCount: Int) throws -> Int {
-        switch(genre) {
-        case .tragedy:
-            return TragedyPerformanceCost().amountFor(attendanceCount: attendanceCount)
-        case .comedy:
-            return ComedyPerformanceCost().amountFor(attendanceCount: attendanceCount)
-        case .unknown:
-            throw UnknownTypeError.unknownTypeError("new play")
-        }
-    }
-    
     func cost(for genre: Play.Genre) throws -> PerformanceCost {
         switch(genre) {
         case .tragedy:

--- a/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
@@ -29,6 +29,22 @@ func generateStatementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>
     }
     
     func costFor(_ genre: Play.Genre, attendanceCount: Int) throws -> Int {
+        try PerformanceCostProvider().costFor(genre, attendanceCount: attendanceCount)
+    }
+    
+    func volumeCreditsFor(_ genre: Play.Genre, attendanceCount: Int) -> Int {
+        var result = 0
+        result += max(attendanceCount - 30, 0)
+        
+        if (.comedy == genre) {
+            result += Int(round(Double(attendanceCount / 5)))
+        }
+        return result
+    }
+}
+
+struct PerformanceCostProvider {
+    func costFor(_ genre: Play.Genre, attendanceCount: Int) throws -> Int {
         var result = 0
         
         switch(genre) {
@@ -47,16 +63,6 @@ func generateStatementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>
             throw UnknownTypeError.unknownTypeError("new play")
         }
         
-        return result
-    }
-    
-    func volumeCreditsFor(_ genre: Play.Genre, attendanceCount: Int) -> Int {
-        var result = 0
-        result += max(attendanceCount - 30, 0)
-        
-        if (.comedy == genre) {
-            result += Int(round(Double(attendanceCount / 5)))
-        }
         return result
     }
 }

--- a/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
@@ -45,22 +45,14 @@ func generateStatementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>
 
 struct PerformanceCostProvider {
     func costFor(_ genre: Play.Genre, attendanceCount: Int) throws -> Int {
-        var result = 0
-        
         switch(genre) {
         case .tragedy:
             return TragedyPerformanceCost().costFor(attendanceCount: attendanceCount)
         case .comedy:
-            result = 30000
-            if (attendanceCount > 20) {
-                result += 10000 + 500 * (attendanceCount - 20)
-            }
-            result += 300 * attendanceCount
+            return ComedyPerformanceCost().costFor(attendanceCount: attendanceCount)
         case .unknown:
             throw UnknownTypeError.unknownTypeError("new play")
         }
-        
-        return result
     }
     
     struct TragedyPerformanceCost {
@@ -69,6 +61,15 @@ struct PerformanceCostProvider {
             let exceededBaseVolume = count > baseVolume
             let additionalVolumeCost = exceededBaseVolume ? 1000 * (count - baseVolume) : 0
             return 40000 + additionalVolumeCost
+        }
+    }
+    
+    struct ComedyPerformanceCost {
+        func costFor(attendanceCount count: Int) -> Int {
+            let baseVolume = 20
+            let exceededBaseVolume = count > baseVolume
+            let additionalVolumeCost = exceededBaseVolume ? 10000 + 500 * (count - baseVolume) : 0
+            return 30000 + additionalVolumeCost + 300 * count
         }
     }
 }

--- a/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
@@ -33,7 +33,10 @@ func generateStatementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>
         
         switch(genre) {
         case .tragedy:
-            return TragedyPerformanceCost().forAudience(count: attendanceCount)
+            result = 40000
+            if (attendanceCount > 30) {
+                result += 1000 * (attendanceCount - 30)
+            }
         case .comedy:
             result = 30000
             if (attendanceCount > 20) {
@@ -45,13 +48,6 @@ func generateStatementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>
         }
         
         return result
-    }
-    
-    struct TragedyPerformanceCost {
-        func forAudience(count: Int) -> Int {
-            let highVolumeCost = count > 30 ? 1000 * (count - 30) : 0
-            return 40000 + highVolumeCost
-        }
     }
     
     func volumeCreditsFor(_ genre: Play.Genre, attendanceCount: Int) -> Int {

--- a/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
@@ -43,41 +43,6 @@ func generateStatementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>
     }
 }
 
-protocol PerformanceCost {
-    func amountFor(attendanceCount count: Int) -> Int
-}
-
-struct PerformanceCostProvider {
-    func cost(for genre: Play.Genre) throws -> PerformanceCost {
-        switch(genre) {
-        case .tragedy:
-            return TragedyPerformanceCost()
-        case .comedy:
-            return ComedyPerformanceCost()
-        case .unknown:
-            throw UnknownTypeError.unknownTypeError("new play")
-        }
-    }
-    
-    struct TragedyPerformanceCost: PerformanceCost {
-        func amountFor(attendanceCount count: Int) -> Int {
-            let baseVolume = 30
-            let exceededBaseVolume = count > baseVolume
-            let additionalVolumeCost = exceededBaseVolume ? 1000 * (count - baseVolume) : 0
-            return 40000 + additionalVolumeCost
-        }
-    }
-    
-    struct ComedyPerformanceCost: PerformanceCost {
-        func amountFor(attendanceCount count: Int) -> Int {
-            let baseVolume = 20
-            let exceededBaseVolume = count > baseVolume
-            let additionalVolumeCost = exceededBaseVolume ? 10000 + 500 * (count - baseVolume) : 0
-            return 30000 + additionalVolumeCost + 300 * count
-        }
-    }
-}
-
 private extension Array where Element == Int {
     var sum: Int {
         self.reduce(0) { $0 + $1 }

--- a/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
@@ -33,10 +33,7 @@ func generateStatementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>
         
         switch(genre) {
         case .tragedy:
-            result = 40000
-            if (attendanceCount > 30) {
-                result += 1000 * (attendanceCount - 30)
-            }
+            return TragedyPerformanceCost().forAudience(count: attendanceCount)
         case .comedy:
             result = 30000
             if (attendanceCount > 20) {
@@ -48,6 +45,13 @@ func generateStatementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>
         }
         
         return result
+    }
+    
+    struct TragedyPerformanceCost {
+        func forAudience(count: Int) -> Int {
+            let highVolumeCost = count > 30 ? 1000 * (count - 30) : 0
+            return 40000 + highVolumeCost
+        }
     }
     
     func volumeCreditsFor(_ genre: Play.Genre, attendanceCount: Int) -> Int {

--- a/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
@@ -29,7 +29,7 @@ func generateStatementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>
     }
     
     func costFor(_ genre: Play.Genre, attendanceCount: Int) throws -> Int {
-        try PerformanceCostProvider().cost(for: genre).costFor(attendanceCount: attendanceCount)
+        try PerformanceCostProvider().cost(for: genre).amountFor(attendanceCount: attendanceCount)
     }
     
     func volumeCreditsFor(_ genre: Play.Genre, attendanceCount: Int) -> Int {
@@ -44,16 +44,16 @@ func generateStatementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>
 }
 
 protocol PerformanceCost {
-    func costFor(attendanceCount count: Int) -> Int
+    func amountFor(attendanceCount count: Int) -> Int
 }
 
 struct PerformanceCostProvider {
     func costFor(_ genre: Play.Genre, attendanceCount: Int) throws -> Int {
         switch(genre) {
         case .tragedy:
-            return TragedyPerformanceCost().costFor(attendanceCount: attendanceCount)
+            return TragedyPerformanceCost().amountFor(attendanceCount: attendanceCount)
         case .comedy:
-            return ComedyPerformanceCost().costFor(attendanceCount: attendanceCount)
+            return ComedyPerformanceCost().amountFor(attendanceCount: attendanceCount)
         case .unknown:
             throw UnknownTypeError.unknownTypeError("new play")
         }
@@ -71,7 +71,7 @@ struct PerformanceCostProvider {
     }
     
     struct TragedyPerformanceCost: PerformanceCost {
-        func costFor(attendanceCount count: Int) -> Int {
+        func amountFor(attendanceCount count: Int) -> Int {
             let baseVolume = 30
             let exceededBaseVolume = count > baseVolume
             let additionalVolumeCost = exceededBaseVolume ? 1000 * (count - baseVolume) : 0
@@ -80,7 +80,7 @@ struct PerformanceCostProvider {
     }
     
     struct ComedyPerformanceCost: PerformanceCost {
-        func costFor(attendanceCount count: Int) -> Int {
+        func amountFor(attendanceCount count: Int) -> Int {
             let baseVolume = 20
             let exceededBaseVolume = count > baseVolume
             let additionalVolumeCost = exceededBaseVolume ? 10000 + 500 * (count - baseVolume) : 0

--- a/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
@@ -1,30 +1,6 @@
 import XCTest
 @testable import Theatrical_Players_Refactoring_Kata
 
-struct PerformanceCostProvider {
-    func costFor(_ genre: Play.Genre, attendanceCount: Int) throws -> Int {
-        var result = 0
-        
-        switch(genre) {
-        case .tragedy:
-            result = 40000
-            if (attendanceCount > 30) {
-                result += 1000 * (attendanceCount - 30)
-            }
-        case .comedy:
-            result = 30000
-            if (attendanceCount > 20) {
-                result += 10000 + 500 * (attendanceCount - 20)
-            }
-            result += 300 * attendanceCount
-        case .unknown:
-            throw UnknownTypeError.unknownTypeError("new play")
-        }
-        
-        return result
-    }
-}
-
 final class PerformanceCostProviderTests: XCTestCase {
     // MARK: Tragedy
     func test_costFor_returnsCostForTragedy() throws {

--- a/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
@@ -3,13 +3,19 @@ import XCTest
 
 final class PerformanceCostProviderTests: XCTestCase {
     // MARK: Tragedy
-    func test_costFor_returnsCostForTragedy() throws {
-        let sut = PerformanceCostProvider()
-        expect(
-            try PerformanceCostProvider().cost(for: .tragedy),
-            withAttendanceCount: Play.Genre.tragedy.baseVolumeAttendanceCount,
-            toBe: 40000
-        )
+    func test_cost_returnsCorrectPerformanceCost() throws {
+        let genreBaseCosts: [(Play.Genre, Int)] = [
+            (.tragedy, 40000),
+            (.comedy, 36000)
+        ]
+        
+        try genreBaseCosts.forEach { (genre, expectedCost) in
+            self.expect(
+                try PerformanceCostProvider().cost(for: genre),
+                withAttendanceCount: genre.baseVolumeAttendanceCount,
+                toBe: expectedCost
+            )
+        }
     }
     
     func test_costFor_returnsAdditionalVolumeCostForTragedy() throws {
@@ -18,17 +24,6 @@ final class PerformanceCostProviderTests: XCTestCase {
         let expectedCost = 41000
         
         let result = try sut.costFor(genre, attendanceCount: genre.additionalVolumeAttendanceCount)
-        
-        XCTAssertEqual(result, expectedCost)
-    }
-    
-    // MARK: Comedy
-    func test_costFor_returnsCostForComedy() throws {
-        let sut = PerformanceCostProvider()
-        let genre: Play.Genre = .comedy
-        let expectedCost = 36000
-        
-        let result = try sut.costFor(genre, attendanceCount: genre.baseVolumeAttendanceCount)
         
         XCTAssertEqual(result, expectedCost)
     }
@@ -53,7 +48,7 @@ final class PerformanceCostProviderTests: XCTestCase {
 
 private extension PerformanceCostProviderTests {
     func expect(_ cost: PerformanceCost, withAttendanceCount count: Int, toBe expectedCost: Int, file: StaticString = #filePath, line: UInt = #line) {
-        XCTAssertEqual(cost.amountFor(attendanceCount: count), expectedCost)
+        XCTAssertEqual(cost.amountFor(attendanceCount: count), expectedCost, "Wrong cost for \(cost) with attendance of \(count)")
     }
 }
 

--- a/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
@@ -35,6 +35,16 @@ final class PerformanceCostProviderTests: XCTestCase {
         
         XCTAssertEqual(result, expectedCost)
     }
+    
+    func test_costFor_returnsAdditionalVolumeCostForTragedy() throws {
+        let sut = PerformanceCostProvider()
+        let genre: Play.Genre = .tragedy
+        let expectedCost = 41000
+        
+        let result = try sut.costFor(genre, attendanceCount: genre.baseVolumeAttendanceCount + 1)
+        
+        XCTAssertEqual(result, expectedCost)
+    }
 }
 
 private extension Play.Genre {

--- a/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
@@ -18,24 +18,19 @@ final class PerformanceCostProviderTests: XCTestCase {
         }
     }
     
-    func test_costFor_returnsAdditionalVolumeCostForTragedy() throws {
-        let sut = PerformanceCostProvider()
-        let genre: Play.Genre = .tragedy
-        let expectedCost = 41000
+    func test_cost_returnsAdditionalVolumeAttendanceCountPerformanceCost() throws {
+        let genreBaseCosts: [(Play.Genre, Int)] = [
+            (.tragedy, 41000),
+            (.comedy, 46800)
+        ]
         
-        let result = try sut.costFor(genre, attendanceCount: genre.additionalVolumeAttendanceCount)
-        
-        XCTAssertEqual(result, expectedCost)
-    }
-    
-    func test_costFor_returnsAdditionalVolumeCostForComedy() throws {
-        let sut = PerformanceCostProvider()
-        let genre: Play.Genre = .comedy
-        let expectedCost = 46800
-        
-        let result = try sut.costFor(genre, attendanceCount: genre.additionalVolumeAttendanceCount)
-        
-        XCTAssertEqual(result, expectedCost)
+        try genreBaseCosts.forEach { (genre, expectedCost) in
+            self.expect(
+                try PerformanceCostProvider().cost(for: genre),
+                withAttendanceCount: genre.additionalVolumeAttendanceCount,
+                toBe: expectedCost
+            )
+        }
     }
     
     // MARK: Unknown

--- a/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
@@ -8,7 +8,7 @@ final class PerformanceCostProviderTests: XCTestCase {
         let genre: Play.Genre = .tragedy
         let expectedCost = 40000
         
-        let result = try sut.costFor(genre, attendanceCount: genre.baseVolumeAttendanceCount)
+        let result = try sut.cost(for: genre).costFor(attendanceCount: genre.baseVolumeAttendanceCount)
         
         XCTAssertEqual(result, expectedCost)
     }

--- a/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
@@ -26,30 +26,19 @@ struct PerformanceCostProvider {
 }
 
 final class PerformanceCostProviderTests: XCTestCase {
-    func test_performanceCost_returnsCostForTragedyWithoutHighVolume() throws {
+    func test_costFor_returnsCostForTragedy() throws {
         let sut = PerformanceCostProvider()
         let genre: Play.Genre = .tragedy
-        let expectedBaseCost = genre.baseCost()
+        let expectedCost = 40000
         
-        let result = try sut.costFor(.tragedy, attendanceCount: genre.baseVolumeAttendanceCount())
+        let result = try sut.costFor(genre, attendanceCount: genre.baseVolumeAttendanceCount)
         
-        XCTAssertEqual(result, expectedBaseCost)
+        XCTAssertEqual(result, expectedCost)
     }
 }
 
 private extension Play.Genre {
-    func baseCost() -> Int {
-        switch self {
-        case .tragedy:
-            return 40000
-        case .comedy:
-            return 30000
-        case .unknown:
-            return 0
-        }
-    }
-    
-    func baseVolumeAttendanceCount() -> Int {
+    var baseVolumeAttendanceCount: Int {
         switch self {
         case .tragedy:
             return 30

--- a/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import Theatrical_Players_Refactoring_Kata
+
+struct PerformanceCostProvider {
+    func costFor(_ genre: Play.Genre, attendanceCount: Int) throws -> Int {
+        var result = 0
+        
+        switch(genre) {
+        case .tragedy:
+            result = 40000
+            if (attendanceCount > 30) {
+                result += 1000 * (attendanceCount - 30)
+            }
+        case .comedy:
+            result = 30000
+            if (attendanceCount > 20) {
+                result += 10000 + 500 * (attendanceCount - 20)
+            }
+            result += 300 * attendanceCount
+        case .unknown:
+            throw UnknownTypeError.unknownTypeError("new play")
+        }
+        
+        return result
+    }
+}
+
+final class PerformanceCostProviderTests: XCTestCase {
+    func test_performanceCost_returnsCostForTragedyWithoutHighVolume() throws {
+        let sut = PerformanceCostProvider()
+        let expectedBaseCost = 40000
+        
+        let result = try sut.costFor(.tragedy, attendanceCount: 10)
+        
+        XCTAssertEqual(result, expectedBaseCost)
+    }
+}

--- a/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
@@ -28,10 +28,23 @@ struct PerformanceCostProvider {
 final class PerformanceCostProviderTests: XCTestCase {
     func test_performanceCost_returnsCostForTragedyWithoutHighVolume() throws {
         let sut = PerformanceCostProvider()
-        let expectedBaseCost = 40000
+        let expectedBaseCost = Play.Genre.tragedy.baseCost()
         
         let result = try sut.costFor(.tragedy, attendanceCount: 10)
         
         XCTAssertEqual(result, expectedBaseCost)
+    }
+}
+
+private extension Play.Genre {
+    func baseCost() -> Int {
+        switch self {
+        case .tragedy:
+            return 40000
+        case .comedy:
+            return 30000
+        case .unknown:
+            return 0
+        }
     }
 }

--- a/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
@@ -28,9 +28,10 @@ struct PerformanceCostProvider {
 final class PerformanceCostProviderTests: XCTestCase {
     func test_performanceCost_returnsCostForTragedyWithoutHighVolume() throws {
         let sut = PerformanceCostProvider()
-        let expectedBaseCost = Play.Genre.tragedy.baseCost()
+        let genre: Play.Genre = .tragedy
+        let expectedBaseCost = genre.baseCost()
         
-        let result = try sut.costFor(.tragedy, attendanceCount: 10)
+        let result = try sut.costFor(.tragedy, attendanceCount: genre.baseVolumeAttendanceCount())
         
         XCTAssertEqual(result, expectedBaseCost)
     }
@@ -43,6 +44,17 @@ private extension Play.Genre {
             return 40000
         case .comedy:
             return 30000
+        case .unknown:
+            return 0
+        }
+    }
+    
+    func baseVolumeAttendanceCount() -> Int {
+        switch self {
+        case .tragedy:
+            return 30
+        case .comedy:
+            return 20
         case .unknown:
             return 0
         }

--- a/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
@@ -3,10 +3,19 @@ import XCTest
 
 final class PerformanceCostProviderTests: XCTestCase {
     func test_cost_returnsCorrectPerformanceCost() throws {
-        let genreBaseCosts: [(Play.Genre, Int)] = [
-            (.tragedy, 40000),
-            (.comedy, 36000)
-        ]
+        let genreBaseCosts: [(Play.Genre, Int)] = Play.Genre.allCases
+            .compactMap {
+                switch $0 {
+                case .tragedy:
+                    return ($0, 40000)
+                case .comedy:
+                    return ($0, 36000)
+                case .pastoral:
+                    return ($0, 30)
+                case .unknown:
+                    return nil
+                }
+            }
         
         try genreBaseCosts.forEach { (genre, expectedCost) in
             self.expect(
@@ -18,12 +27,21 @@ final class PerformanceCostProviderTests: XCTestCase {
     }
     
     func test_cost_returnsAdditionalVolumeAttendanceCountPerformanceCost() throws {
-        let genreBaseCosts: [(Play.Genre, Int)] = [
-            (.tragedy, 41000),
-            (.comedy, 46800)
-        ]
+        let genreAdditionalVolumeCosts: [(Play.Genre, Int)] = Play.Genre.allCases
+            .compactMap {
+                switch $0 {
+                case .tragedy:
+                    return ($0, 41000)
+                case .comedy:
+                    return ($0, 46800)
+                case .pastoral:
+                    return ($0, 30)
+                case .unknown:
+                    return nil
+                }
+            }
         
-        try genreBaseCosts.forEach { (genre, expectedCost) in
+        try genreAdditionalVolumeCosts.forEach { (genre, expectedCost) in
             self.expect(
                 try PerformanceCostProvider().cost(for: genre),
                 withAttendanceCount: genre.additionalVolumeAttendanceCount,
@@ -54,6 +72,8 @@ private extension Play.Genre {
             return 30
         case .comedy:
             return 20
+        case .pastoral:
+            return 0
         case .unknown:
             return 0
         }

--- a/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
@@ -5,12 +5,11 @@ final class PerformanceCostProviderTests: XCTestCase {
     // MARK: Tragedy
     func test_costFor_returnsCostForTragedy() throws {
         let sut = PerformanceCostProvider()
-        let genre: Play.Genre = .tragedy
-        let expectedCost = 40000
-        
-        let result = try sut.cost(for: genre).amountFor(attendanceCount: genre.baseVolumeAttendanceCount)
-        
-        XCTAssertEqual(result, expectedCost)
+        expect(
+            try PerformanceCostProvider().cost(for: .tragedy),
+            withAttendanceCount: Play.Genre.tragedy.baseVolumeAttendanceCount,
+            toBe: 40000
+        )
     }
     
     func test_costFor_returnsAdditionalVolumeCostForTragedy() throws {
@@ -49,6 +48,12 @@ final class PerformanceCostProviderTests: XCTestCase {
         let sut = PerformanceCostProvider()
         
         XCTAssertThrowsError(try sut.costFor(.unknown, attendanceCount: 100))
+    }
+}
+
+private extension PerformanceCostProviderTests {
+    func expect(_ cost: PerformanceCost, withAttendanceCount count: Int, toBe expectedCost: Int, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(cost.amountFor(attendanceCount: count), expectedCost)
     }
 }
 

--- a/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
@@ -57,6 +57,16 @@ final class PerformanceCostProviderTests: XCTestCase {
         
         XCTAssertEqual(result, expectedCost)
     }
+    
+    func test_costFor_returnsAdditionalVolumeCostForComedy() throws {
+        let sut = PerformanceCostProvider()
+        let genre: Play.Genre = .comedy
+        let expectedCost = 46800
+        
+        let result = try sut.costFor(genre, attendanceCount: genre.additionalVolumeAttendanceCount)
+        
+        XCTAssertEqual(result, expectedCost)
+    }
 }
 
 private extension Play.Genre {

--- a/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
@@ -2,7 +2,6 @@ import XCTest
 @testable import Theatrical_Players_Refactoring_Kata
 
 final class PerformanceCostProviderTests: XCTestCase {
-    // MARK: Tragedy
     func test_cost_returnsCorrectPerformanceCost() throws {
         let genreBaseCosts: [(Play.Genre, Int)] = [
             (.tragedy, 40000),
@@ -33,11 +32,12 @@ final class PerformanceCostProviderTests: XCTestCase {
         }
     }
     
-    // MARK: Unknown
+    // MARK: Errors
+    
     func test_costFor_throwsNewPlayErrorOnUknownGenre() throws {
         let sut = PerformanceCostProvider()
         
-        XCTAssertThrowsError(try sut.costFor(.unknown, attendanceCount: 100))
+        XCTAssertThrowsError(try sut.cost(for: .unknown))
     }
 }
 

--- a/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
@@ -67,6 +67,13 @@ final class PerformanceCostProviderTests: XCTestCase {
         
         XCTAssertEqual(result, expectedCost)
     }
+    
+    // MARK: Unknown
+    func test_costFor_throwsNewPlayErrorOnUknownGenre() throws {
+        let sut = PerformanceCostProvider()
+        
+        XCTAssertThrowsError(try sut.costFor(.unknown, attendanceCount: 100))
+    }
 }
 
 private extension Play.Genre {

--- a/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
@@ -8,7 +8,7 @@ final class PerformanceCostProviderTests: XCTestCase {
         let genre: Play.Genre = .tragedy
         let expectedCost = 40000
         
-        let result = try sut.cost(for: genre).costFor(attendanceCount: genre.baseVolumeAttendanceCount)
+        let result = try sut.cost(for: genre).amountFor(attendanceCount: genre.baseVolumeAttendanceCount)
         
         XCTAssertEqual(result, expectedCost)
     }

--- a/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
@@ -41,7 +41,7 @@ final class PerformanceCostProviderTests: XCTestCase {
         let genre: Play.Genre = .tragedy
         let expectedCost = 41000
         
-        let result = try sut.costFor(genre, attendanceCount: genre.baseVolumeAttendanceCount + 1)
+        let result = try sut.costFor(genre, attendanceCount: genre.additionalVolumeAttendanceCount)
         
         XCTAssertEqual(result, expectedCost)
     }
@@ -57,5 +57,9 @@ private extension Play.Genre {
         case .unknown:
             return 0
         }
+    }
+    
+    var additionalVolumeAttendanceCount: Int {
+        baseVolumeAttendanceCount + 1
     }
 }

--- a/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
@@ -26,6 +26,7 @@ struct PerformanceCostProvider {
 }
 
 final class PerformanceCostProviderTests: XCTestCase {
+    // MARK: Tragedy
     func test_costFor_returnsCostForTragedy() throws {
         let sut = PerformanceCostProvider()
         let genre: Play.Genre = .tragedy
@@ -42,6 +43,17 @@ final class PerformanceCostProviderTests: XCTestCase {
         let expectedCost = 41000
         
         let result = try sut.costFor(genre, attendanceCount: genre.additionalVolumeAttendanceCount)
+        
+        XCTAssertEqual(result, expectedCost)
+    }
+    
+    // MARK: Comedy
+    func test_costFor_returnsCostForComedy() throws {
+        let sut = PerformanceCostProvider()
+        let genre: Play.Genre = .comedy
+        let expectedCost = 36000
+        
+        let result = try sut.costFor(genre, attendanceCount: genre.baseVolumeAttendanceCount)
         
         XCTAssertEqual(result, expectedCost)
     }

--- a/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
@@ -15,7 +15,7 @@ class StatementPrinterTests: XCTestCase {
             """
         let sut = StatementPrinter()
         
-        let result = try sut.generateStatement(invoiceWithKnownPlays(), knownPlays())
+        let result = try sut.generateStatement(invoiceWithKnownPlaysPrinting(), knownPlaysPrinting())
         
         XCTAssertEqual(result, expectedStatementPlainText)
     }
@@ -34,7 +34,7 @@ class StatementPrinterTests: XCTestCase {
             """
         
         let sut = StatementPrinter()
-        let result = try sut.generateStatementHTML(invoiceWithKnownPlays(), knownPlays())
+        let result = try sut.generateStatementHTML(invoiceWithKnownPlaysPrinting(), knownPlaysPrinting())
         
         XCTAssertEqual(result, expectedStatementHTML)
     }
@@ -73,7 +73,7 @@ class StatementPrinterTests: XCTestCase {
 }
 
 extension StatementPrinterTests {
-    func knownPlays() -> Dictionary<String, Play> {
+    func knownPlaysPrinting() -> Dictionary<String, Play> {
         [
             "hamlet": Play(name: "Hamlet", genre: .tragedy),
             "as-like": Play(name: "As You Like It", genre: .comedy),
@@ -81,21 +81,7 @@ extension StatementPrinterTests {
         ]
     }
     
-    func newPlay() -> Dictionary<String, Play> {
-        [
-            "henry-v": Play(name: "Henry V", genre: .unknown),
-            "as-like": Play(name: "As You Like It", genre: .unknown)
-        ]
-    }
-    
-    func missingPlay() -> Dictionary<String, Play> {
-        [
-            "hamlet": Play(name: "Hamlet", genre: .tragedy),
-            "as-like": Play(name: "As You Like It", genre: .tragedy)
-        ]
-    }
-    
-    func invoiceWithKnownPlays() -> Invoice {
+    func invoiceWithKnownPlaysPrinting() -> Invoice {
         Invoice(
             customer: "BigCo", performances: [
                 Performance(playID: "hamlet", audience: 55),
@@ -105,12 +91,46 @@ extension StatementPrinterTests {
         )
     }
     
+    func missingPlay() -> Dictionary<String, Play> {
+        [
+            "hamlet": Play(name: "Hamlet", genre: .tragedy),
+            "as-like": Play(name: "As You Like It", genre: .tragedy)
+        ]
+    }
+    
+    func newPlay() -> Dictionary<String, Play> {
+        [
+            "new": Play(name: "Who Knows", genre: .unknown),
+            "so-new": Play(name: "Whatever", genre: .unknown)
+        ]
+    }
+    
     func invoiceWithNewPlay() -> Invoice {
         Invoice(
             customer: "BigCo", 
             performances: [
-                Performance(playID: "henry-v", audience: 53),
-                Performance(playID: "as-like", audience: 55)
+                Performance(playID: "new", audience: 53),
+                Performance(playID: "so-new", audience: 55)
+            ]
+        )
+    }
+    
+    func knownPlays() -> Dictionary<String, Play> {
+        [
+            "hamlet": Play(name: "Hamlet", genre: .tragedy),
+            "as-like": Play(name: "As You Like It", genre: .comedy),
+            "othello": Play(name: "Othello", genre: .tragedy),
+            "henry-v": Play(name: "Henry V As You Like It", genre: .pastoral)
+        ]
+    }
+    
+    func invoiceWithKnownPlays() -> Invoice {
+        Invoice(
+            customer: "BigCo", performances: [
+                Performance(playID: "hamlet", audience: 55),
+                Performance(playID: "as-like", audience: 35),
+                Performance(playID: "othello", audience: 40),
+                Performance(playID: "henry-v", audience: 53)
             ]
         )
     }

--- a/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
@@ -20,6 +20,25 @@ class StatementPrinterTests: XCTestCase {
         XCTAssertEqual(result, expectedStatementPlainText)
     }
     
+    func test_generateStatementHTML_producesHTMLFormattedStatementForKnownPlays() throws {
+        let expectedStatementHTML = """
+            <h1>Statement for BigCo</h1>
+            <table>
+            <tr><th>play</th><th>seats</th><th>cost</th></tr><tr><td>Hamlet</td><td>55</td><td>$650.00</td></tr>
+            <tr><td>As You Like It</td><td>35</td><td>$580.00</td></tr>
+            <tr><td>Othello</td><td>40</td><td>$500.00</td></tr>
+            </table>
+            <p>Amount owed is <em>$1,730.00</em></p>
+            <p>You earned <em>47</em> credits</p>
+            
+            """
+        
+        let sut = StatementPrinter()
+        let result = try sut.generateStatementHTML(invoiceWithKnownPlays(), knownPlays())
+        
+        XCTAssertEqual(result, expectedStatementHTML)
+    }
+    
     func test_generateStatement_throwsErrorOnNewPlayTypes() {
         let sut = StatementPrinter()
         let expectedError = UnknownTypeError.unknownTypeError("new play")
@@ -50,25 +69,6 @@ class StatementPrinterTests: XCTestCase {
         }
         
         XCTAssertEqual(unknownPlayError, expectedError)
-    }
-    
-    func test_generateStatementHTML_producesHTMLFormattedStatementForKnownPlays() throws {
-        let expectedStatementHTML = """
-            <h1>Statement for BigCo</h1>
-            <table>
-            <tr><th>play</th><th>seats</th><th>cost</th></tr><tr><td>Hamlet</td><td>55</td><td>$650.00</td></tr>
-            <tr><td>As You Like It</td><td>35</td><td>$580.00</td></tr>
-            <tr><td>Othello</td><td>40</td><td>$500.00</td></tr>
-            </table>
-            <p>Amount owed is <em>$1,730.00</em></p>
-            <p>You earned <em>47</em> credits</p>
-            
-            """
-        
-        let sut = StatementPrinter()
-        let result = try sut.generateStatementHTML(invoiceWithKnownPlays(), knownPlays())
-        
-        XCTAssertEqual(result, expectedStatementHTML)
     }
 }
 


### PR DESCRIPTION
This pull request aims to add support for a new `Genre`. Refactoring code to make it easier to add new genres. It refactors the Performance Cost Provider to calculate costs based on attendance and genre types. It also adds tests for the Performance Cost Provider to ensure accurate cost calculation. The changes include adding new files for Performance Cost Provider implementation and its tests. The goal is to improve the accuracy and maintainability of the cost calculation logic. 

### How to test?
Ensure that the new cost calculations for different genres and attendance counts are accurate by running the provided test cases in PerformanceCostProviderTests.

### Why make this change?
The refactor aims to enhance the clarity and efficiency of the performance cost calculation logic, making it easier to maintain and extend in the future.

---

Encapsulate performance cost calculation for tragedy genre

Group printing tests

Revert "Encapsulate performance cost calculation for tragedy genre"

This reverts commit 367a86f602cdfad386a5051d2736b518b859f548.

Base performance cost for `tragedy` genre is 40000

Add expected base costs for genres as test helper

Extract current attendance counts for genres into test helper

Replace test cost expectation helper with explicit cost and improve naming

Cost for tragedy genre, with +1 over base volume attendance count, is 41000

Add helper for additional volume count

Cost for comedy genre at 20 attendees (base volume) is 36000

Cost for comedy genre at 21 attendees (additional volume) is 46800

`PerformanceCostProvider.costFor` throws error on `unknown` (new play) genre

Integrate `PerformanceCostProvider` with production

Extract tragedy genre performance cost calculation

Extract comedy genre performance cost calculation

Add `PerformanceCost` protocol and method to return instances conforming to it

Update cost method naming

Add test helper method to setup for new genre testing

Refactor base cost tests for genres into one test

Consolidate genre additional volume attendance count tests

Update error handling and remove old cost method form provider

Move `PerformanceCostProvider` into it's own file

Add pastoral Play genre

test with new `pastoral` `Play`