### PR TITLE
Transfer volume credits responsibility to `LineItemProvider`

### DIFF
--- a/Theatrical-Players-Refactoring-Kata.xcodeproj/project.pbxproj
+++ b/Theatrical-Players-Refactoring-Kata.xcodeproj/project.pbxproj
@@ -18,7 +18,7 @@
 		8C46E75D2BFBDED800127562 /* StatementDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C46E75C2BFBDED800127562 /* StatementDataProvider.swift */; };
 		8C46E75F2BFBF1E500127562 /* StatementData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C46E75E2BFBF1E500127562 /* StatementData.swift */; };
 		8C46E7632BFE3C6600127562 /* PerformanceCostProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C46E7622BFE3C6600127562 /* PerformanceCostProviderTests.swift */; };
-		8C46E7652BFE73BC00127562 /* PerformanceCostProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C46E7642BFE73BC00127562 /* PerformanceCostProvider.swift */; };
+		8C46E7652BFE73BC00127562 /* LineItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C46E7642BFE73BC00127562 /* LineItemProvider.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,7 +46,7 @@
 		8C46E75C2BFBDED800127562 /* StatementDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatementDataProvider.swift; sourceTree = "<group>"; };
 		8C46E75E2BFBF1E500127562 /* StatementData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatementData.swift; sourceTree = "<group>"; };
 		8C46E7622BFE3C6600127562 /* PerformanceCostProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceCostProviderTests.swift; sourceTree = "<group>"; };
-		8C46E7642BFE73BC00127562 /* PerformanceCostProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceCostProvider.swift; sourceTree = "<group>"; };
+		8C46E7642BFE73BC00127562 /* LineItemProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineItemProvider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -98,7 +98,7 @@
 				104F7D94232831E000665957 /* StatementPrinter.swift */,
 				8C46E75C2BFBDED800127562 /* StatementDataProvider.swift */,
 				8C46E75E2BFBF1E500127562 /* StatementData.swift */,
-				8C46E7642BFE73BC00127562 /* PerformanceCostProvider.swift */,
+				8C46E7642BFE73BC00127562 /* LineItemProvider.swift */,
 			);
 			path = "Theatrical-Players-Refactoring-Kata";
 			sourceTree = "<group>";
@@ -228,7 +228,7 @@
 				104F7D932328312700665957 /* Invoice.swift in Sources */,
 				104F7D95232831E000665957 /* StatementPrinter.swift in Sources */,
 				8C46E75F2BFBF1E500127562 /* StatementData.swift in Sources */,
-				8C46E7652BFE73BC00127562 /* PerformanceCostProvider.swift in Sources */,
+				8C46E7652BFE73BC00127562 /* LineItemProvider.swift in Sources */,
 				104F7D8F2328305A00665957 /* Play.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Theatrical-Players-Refactoring-Kata.xcodeproj/project.pbxproj
+++ b/Theatrical-Players-Refactoring-Kata.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 		8C46E75B2BFBD99700127562 /* PerformanceCharge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C46E75A2BFBD99700127562 /* PerformanceCharge.swift */; };
 		8C46E75D2BFBDED800127562 /* StatementDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C46E75C2BFBDED800127562 /* StatementDataProvider.swift */; };
 		8C46E75F2BFBF1E500127562 /* StatementData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C46E75E2BFBF1E500127562 /* StatementData.swift */; };
-		8C46E7632BFE3C6600127562 /* PerformanceCostProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C46E7622BFE3C6600127562 /* PerformanceCostProviderTests.swift */; };
+		8C46E7632BFE3C6600127562 /* LineItemProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C46E7622BFE3C6600127562 /* LineItemProviderTests.swift */; };
 		8C46E7652BFE73BC00127562 /* LineItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C46E7642BFE73BC00127562 /* LineItemProvider.swift */; };
 /* End PBXBuildFile section */
 
@@ -45,7 +45,7 @@
 		8C46E75A2BFBD99700127562 /* PerformanceCharge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceCharge.swift; sourceTree = "<group>"; };
 		8C46E75C2BFBDED800127562 /* StatementDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatementDataProvider.swift; sourceTree = "<group>"; };
 		8C46E75E2BFBF1E500127562 /* StatementData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatementData.swift; sourceTree = "<group>"; };
-		8C46E7622BFE3C6600127562 /* PerformanceCostProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceCostProviderTests.swift; sourceTree = "<group>"; };
+		8C46E7622BFE3C6600127562 /* LineItemProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineItemProviderTests.swift; sourceTree = "<group>"; };
 		8C46E7642BFE73BC00127562 /* LineItemProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineItemProvider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -108,7 +108,7 @@
 			children = (
 				104F7D8223282F2900665957 /* StatementPrinterTests.swift */,
 				104F7D8423282F2900665957 /* Info.plist */,
-				8C46E7622BFE3C6600127562 /* PerformanceCostProviderTests.swift */,
+				8C46E7622BFE3C6600127562 /* LineItemProviderTests.swift */,
 			);
 			path = "Theatrical-Players-Refactoring-KataTests";
 			sourceTree = "<group>";
@@ -237,7 +237,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8C46E7632BFE3C6600127562 /* PerformanceCostProviderTests.swift in Sources */,
+				8C46E7632BFE3C6600127562 /* LineItemProviderTests.swift in Sources */,
 				104F7D8323282F2900665957 /* StatementPrinterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Theatrical-Players-Refactoring-Kata/LineItemProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/LineItemProvider.swift
@@ -16,6 +16,12 @@ struct LineItemProvider {
         }
     }
     
+    func volumeCredits(for genre: Play.Genre) -> LineItemTotal {
+        return DefaultVolumeCredits()
+    }
+    
+    // MARK: Line Items
+    
     struct TragedyCost: LineItemTotal {
         func amountFor(attendanceCount count: Int) -> Int {
             let baseVolume = 30
@@ -38,5 +44,13 @@ struct LineItemProvider {
         func amountFor(attendanceCount count: Int) -> Int {
             return 30
         }
+    }
+    
+    struct DefaultVolumeCredits: LineItemTotal {
+        func amountFor(attendanceCount count: Int) -> Int {
+            return 0
+        }
+        
+        
     }
 }

--- a/Theatrical-Players-Refactoring-Kata/LineItemProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/LineItemProvider.swift
@@ -48,7 +48,7 @@ struct LineItemProvider {
     
     struct DefaultVolumeCredits: LineItemTotal {
         func amountFor(attendanceCount count: Int) -> Int {
-            return 0
+            max(count - 30, 0)
         }
         
         

--- a/Theatrical-Players-Refactoring-Kata/LineItemProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/LineItemProvider.swift
@@ -2,21 +2,21 @@ protocol LineItemTotal {
     func amountFor(attendanceCount count: Int) -> Int
 }
 
-struct PerformanceCostProvider {
+struct LineItemProvider {
     func cost(for genre: Play.Genre) throws -> LineItemTotal {
         switch(genre) {
         case .tragedy:
-            return Tragedy()
+            return TragedyCost()
         case .comedy:
-            return Comedy()
+            return ComedyCost()
         case .pastoral:
-            return Pastoral()
+            return PastoralCost()
         case .unknown:
             throw UnknownTypeError.unknownTypeError("new play")
         }
     }
     
-    struct Tragedy: LineItemTotal {
+    struct TragedyCost: LineItemTotal {
         func amountFor(attendanceCount count: Int) -> Int {
             let baseVolume = 30
             let exceededBaseVolume = count > baseVolume
@@ -25,7 +25,7 @@ struct PerformanceCostProvider {
         }
     }
     
-    struct Comedy: LineItemTotal {
+    struct ComedyCost: LineItemTotal {
         func amountFor(attendanceCount count: Int) -> Int {
             let baseVolume = 20
             let exceededBaseVolume = count > baseVolume
@@ -34,7 +34,7 @@ struct PerformanceCostProvider {
         }
     }
     
-    struct Pastoral: LineItemTotal {
+    struct PastoralCost: LineItemTotal {
         func amountFor(attendanceCount count: Int) -> Int {
             return 30
         }

--- a/Theatrical-Players-Refactoring-Kata/LineItemProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/LineItemProvider.swift
@@ -17,7 +17,12 @@ struct LineItemProvider {
     }
     
     func volumeCredits(for genre: Play.Genre) -> LineItemTotal {
-        return DefaultVolumeCredits()
+        switch(genre) {
+        case .comedy:
+            ComedyVolumeCredits()
+        case .pastoral, .tragedy, .unknown:
+            DefaultVolumeCredits()
+        }
     }
     
     // MARK: Line Items
@@ -48,9 +53,19 @@ struct LineItemProvider {
     
     struct DefaultVolumeCredits: LineItemTotal {
         func amountFor(attendanceCount count: Int) -> Int {
-            max(count - 30, 0)
+            defaultVolumeCredits(attendance: count)
         }
-        
-        
+    }
+    
+    struct ComedyVolumeCredits: LineItemTotal {
+        func amountFor(attendanceCount count: Int) -> Int {
+            defaultVolumeCredits(attendance: count) + Int(round(Double(count / 5)))
+        }
+    }
+}
+
+private extension LineItemTotal {
+    func defaultVolumeCredits(attendance count: Int) -> Int {
+        max(count - 30, 0)
     }
 }

--- a/Theatrical-Players-Refactoring-Kata/PerformanceCostProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/PerformanceCostProvider.swift
@@ -1,9 +1,9 @@
-protocol PerformanceCost {
+protocol LineItemTotal {
     func amountFor(attendanceCount count: Int) -> Int
 }
 
 struct PerformanceCostProvider {
-    func cost(for genre: Play.Genre) throws -> PerformanceCost {
+    func cost(for genre: Play.Genre) throws -> LineItemTotal {
         switch(genre) {
         case .tragedy:
             return Tragedy()
@@ -16,7 +16,7 @@ struct PerformanceCostProvider {
         }
     }
     
-    struct Tragedy: PerformanceCost {
+    struct Tragedy: LineItemTotal {
         func amountFor(attendanceCount count: Int) -> Int {
             let baseVolume = 30
             let exceededBaseVolume = count > baseVolume
@@ -25,7 +25,7 @@ struct PerformanceCostProvider {
         }
     }
     
-    struct Comedy: PerformanceCost {
+    struct Comedy: LineItemTotal {
         func amountFor(attendanceCount count: Int) -> Int {
             let baseVolume = 20
             let exceededBaseVolume = count > baseVolume
@@ -34,7 +34,7 @@ struct PerformanceCostProvider {
         }
     }
     
-    struct Pastoral: PerformanceCost {
+    struct Pastoral: LineItemTotal {
         func amountFor(attendanceCount count: Int) -> Int {
             return 30
         }

--- a/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
@@ -13,7 +13,7 @@ func generateStatementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>
                 try play(for: performance.playID).genre,
                 attendanceCount: performance.audience
             ),
-            volumeCredits: volumeCreditsFor(
+            volumeCredits: try volumeCreditsFor(
                 try play(for: performance.playID).genre,
                 attendanceCount: performance.audience
             ),
@@ -32,14 +32,8 @@ func generateStatementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>
         try LineItemProvider().cost(for: genre).amountFor(attendanceCount: attendanceCount)
     }
     
-    func volumeCreditsFor(_ genre: Play.Genre, attendanceCount: Int) -> Int {
-        var result = 0
-        result += max(attendanceCount - 30, 0)
-        
-        if (.comedy == genre) {
-            result += Int(round(Double(attendanceCount / 5)))
-        }
-        return result
+    func volumeCreditsFor(_ genre: Play.Genre, attendanceCount: Int) throws -> Int {
+        LineItemProvider().volumeCredits(for: genre).amountFor(attendanceCount: attendanceCount)
     }
 }
 

--- a/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
@@ -29,7 +29,7 @@ func generateStatementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>
     }
     
     func costFor(_ genre: Play.Genre, attendanceCount: Int) throws -> Int {
-        try PerformanceCostProvider().cost(for: genre).amountFor(attendanceCount: attendanceCount)
+        try LineItemProvider().cost(for: genre).amountFor(attendanceCount: attendanceCount)
     }
     
     func volumeCreditsFor(_ genre: Play.Genre, attendanceCount: Int) -> Int {

--- a/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/StatementDataProvider.swift
@@ -13,7 +13,7 @@ func generateStatementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>
                 try play(for: performance.playID).genre,
                 attendanceCount: performance.audience
             ),
-            volumeCredits: try volumeCreditsFor(
+            volumeCredits: volumeCreditsFor(
                 try play(for: performance.playID).genre,
                 attendanceCount: performance.audience
             ),
@@ -32,7 +32,7 @@ func generateStatementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>
         try LineItemProvider().cost(for: genre).amountFor(attendanceCount: attendanceCount)
     }
     
-    func volumeCreditsFor(_ genre: Play.Genre, attendanceCount: Int) throws -> Int {
+    func volumeCreditsFor(_ genre: Play.Genre, attendanceCount: Int) -> Int {
         LineItemProvider().volumeCredits(for: genre).amountFor(attendanceCount: attendanceCount)
     }
 }

--- a/Theatrical-Players-Refactoring-KataTests/LineItemProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/LineItemProviderTests.swift
@@ -53,13 +53,15 @@ final class LineItemProviderTests: XCTestCase {
     
     // MARK: Volume Credits
     
-    func test_volumeCredits_returnsZeroWithInsufficientAudienceCountForDefaultGenres() {
+    func test_volumeCredits_returnsCorrectAmountWithBaseAudienceCount() {
         let genresForVolumeCredits: [(Play.Genre, Int)] = Play.Genre.allCases
             .compactMap {
                 switch $0 {
                 case .tragedy, .pastoral:
                     return ($0, 0)
-                case .comedy, .unknown:
+                case .comedy:
+                    return ($0, 6)
+                case .unknown:
                     return nil
                 }
             }

--- a/Theatrical-Players-Refactoring-KataTests/LineItemProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/LineItemProviderTests.swift
@@ -73,6 +73,16 @@ final class LineItemProviderTests: XCTestCase {
         XCTAssertEqual(expected, actual)
     }
     
+    func test_volumeCredits_returnsCorrectAmountForComedy() {
+        let sut = LineItemProvider()
+        let genre: Play.Genre = .comedy
+        let expected = 4
+        
+        let actual = sut.volumeCredits(for: genre).amountFor(attendanceCount: genre.additionalVolumeAttendanceCount)
+        
+        XCTAssertEqual(expected, actual)
+    }
+    
     // MARK: - Errors
     
     func test_costFor_throwsNewPlayErrorOnUknownGenre() throws {

--- a/Theatrical-Players-Refactoring-KataTests/LineItemProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/LineItemProviderTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import Theatrical_Players_Refactoring_Kata
 
-final class PerformanceCostProviderTests: XCTestCase {
+final class LineItemProviderTests: XCTestCase {
     func test_cost_returnsCorrectPerformanceCost() throws {
         let genreBaseCosts: [(Play.Genre, Int)] = Play.Genre.allCases
             .compactMap {
@@ -59,7 +59,7 @@ final class PerformanceCostProviderTests: XCTestCase {
     }
 }
 
-private extension PerformanceCostProviderTests {
+private extension LineItemProviderTests {
     func expect(_ cost: LineItemTotal, withAttendanceCount count: Int, toBe expectedCost: Int, file: StaticString = #filePath, line: UInt = #line) {
         XCTAssertEqual(cost.amountFor(attendanceCount: count), expectedCost, "Wrong cost for \(cost) with attendance of \(count)")
     }

--- a/Theatrical-Players-Refactoring-KataTests/LineItemProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/LineItemProviderTests.swift
@@ -53,12 +53,22 @@ final class LineItemProviderTests: XCTestCase {
     
     // MARK: Volume Credits
     
-    func test_volumeCredits_returnsZeroCreditsWithInsufficientAudienceCount() {
+    func test_volumeCredits_returnsZeroWithInsufficientAudienceCountForTragedy() {
         let sut = LineItemProvider()
         let genre: Play.Genre = .tragedy
         let expected = 0
 
-        let actual = sut.volumeCredits(for: genre).amountFor(attendanceCount: 5)
+        let actual = sut.volumeCredits(for: genre).amountFor(attendanceCount: genre.baseVolumeAttendanceCount)
+        
+        XCTAssertEqual(expected, actual)
+    }
+    
+    func test_volumeCredits_returnsCorrectAmountForTragedy() {
+        let sut = LineItemProvider()
+        let genre: Play.Genre = .tragedy
+        let expected = 1
+        
+        let actual = sut.volumeCredits(for: genre).amountFor(attendanceCount: genre.additionalVolumeAttendanceCount)
         
         XCTAssertEqual(expected, actual)
     }

--- a/Theatrical-Players-Refactoring-KataTests/LineItemProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/LineItemProviderTests.swift
@@ -75,6 +75,28 @@ final class LineItemProviderTests: XCTestCase {
         }
     }
     
+    func test_volumeCredits_returnsCorrectAmountUponExceedingBaseAudienceCount() {
+        let genresForVolumeCredits: [(Play.Genre, Int)] = Play.Genre.allCases
+            .compactMap {
+                switch $0 {
+                case .tragedy, .pastoral:
+                    return ($0, 1)
+                case .comedy:
+                    return ($0, 7)
+                case .unknown:
+                    return nil
+                }
+            }
+        
+        genresForVolumeCredits.forEach { (genre, expectedAmount) in
+            self.expect(
+                LineItemProvider().volumeCredits(for: genre),
+                withAttendanceCount: 31,
+                toBe: expectedAmount
+            )
+        }
+    }
+    
     func test_volumeCredits_returnsCorrectAmountForTragedy() {
         let sut = LineItemProvider()
         let genre: Play.Genre = .tragedy

--- a/Theatrical-Players-Refactoring-KataTests/LineItemProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/LineItemProviderTests.swift
@@ -97,26 +97,6 @@ final class LineItemProviderTests: XCTestCase {
         }
     }
     
-    func test_volumeCredits_returnsCorrectAmountForTragedy() {
-        let sut = LineItemProvider()
-        let genre: Play.Genre = .tragedy
-        let expected = 1
-        
-        let actual = sut.volumeCredits(for: genre).amountFor(attendanceCount: genre.additionalVolumeAttendanceCount)
-        
-        XCTAssertEqual(expected, actual)
-    }
-    
-    func test_volumeCredits_returnsCorrectAmountForComedy() {
-        let sut = LineItemProvider()
-        let genre: Play.Genre = .comedy
-        let expected = 4
-        
-        let actual = sut.volumeCredits(for: genre).amountFor(attendanceCount: genre.additionalVolumeAttendanceCount)
-        
-        XCTAssertEqual(expected, actual)
-    }
-    
     // MARK: - Errors
     
     func test_costFor_throwsNewPlayErrorOnUknownGenre() throws {

--- a/Theatrical-Players-Refactoring-KataTests/LineItemProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/LineItemProviderTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import Theatrical_Players_Refactoring_Kata
 
 final class LineItemProviderTests: XCTestCase {
+    // MARK: - Success
     func test_cost_returnsCorrectPerformanceCost() throws {
         let genreBaseCosts: [(Play.Genre, Int)] = Play.Genre.allCases
             .compactMap {
@@ -50,7 +51,19 @@ final class LineItemProviderTests: XCTestCase {
         }
     }
     
-    // MARK: Errors
+    // MARK: Volume Credits
+    
+    func test_volumeCredits_returnsZeroCreditsWithInsufficientAudienceCount() {
+        let sut = LineItemProvider()
+        let genre: Play.Genre = .tragedy
+        let expected = 0
+
+        let actual = sut.volumeCredits(for: genre).amountFor(attendanceCount: 5)
+        
+        XCTAssertEqual(expected, actual)
+    }
+    
+    // MARK: - Errors
     
     func test_costFor_throwsNewPlayErrorOnUknownGenre() throws {
         let sut = LineItemProvider()

--- a/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
@@ -60,7 +60,7 @@ final class PerformanceCostProviderTests: XCTestCase {
 }
 
 private extension PerformanceCostProviderTests {
-    func expect(_ cost: PerformanceCost, withAttendanceCount count: Int, toBe expectedCost: Int, file: StaticString = #filePath, line: UInt = #line) {
+    func expect(_ cost: LineItemTotal, withAttendanceCount count: Int, toBe expectedCost: Int, file: StaticString = #filePath, line: UInt = #line) {
         XCTAssertEqual(cost.amountFor(attendanceCount: count), expectedCost, "Wrong cost for \(cost) with attendance of \(count)")
     }
 }

--- a/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
+++ b/Theatrical-Players-Refactoring-KataTests/PerformanceCostProviderTests.swift
@@ -19,7 +19,7 @@ final class PerformanceCostProviderTests: XCTestCase {
         
         try genreBaseCosts.forEach { (genre, expectedCost) in
             self.expect(
-                try PerformanceCostProvider().cost(for: genre),
+                try LineItemProvider().cost(for: genre),
                 withAttendanceCount: genre.baseVolumeAttendanceCount,
                 toBe: expectedCost
             )
@@ -43,7 +43,7 @@ final class PerformanceCostProviderTests: XCTestCase {
         
         try genreAdditionalVolumeCosts.forEach { (genre, expectedCost) in
             self.expect(
-                try PerformanceCostProvider().cost(for: genre),
+                try LineItemProvider().cost(for: genre),
                 withAttendanceCount: genre.additionalVolumeAttendanceCount,
                 toBe: expectedCost
             )
@@ -53,7 +53,7 @@ final class PerformanceCostProviderTests: XCTestCase {
     // MARK: Errors
     
     func test_costFor_throwsNewPlayErrorOnUknownGenre() throws {
-        let sut = PerformanceCostProvider()
+        let sut = LineItemProvider()
         
         XCTAssertThrowsError(try sut.cost(for: .unknown))
     }


### PR DESCRIPTION
This transfers the responsibility of volume credits calculation to the `LineItemProvider` for the purpose of testing that functionality more easily, and in better isolation.

---

Rename `<PerformanceCost>` to `<LineItemTotal>` in preparation for use as an abstraction to other calculated amounts

Rename `PerformanceCostProvider` to `LineItemProvider` with current cost `LineItem`s naming updated to reflect purposes

Update tests name for line item provider

`LineItemeProvider.volumeCredits` `LineItemTotal` returns 0 with insufficient audience count

`LineItemProvider.volumeCredits` returns correct amount for tragedy genre

`LineItem` returns correct amount of volume credits for `.comedy` genre

All genres that use the default volume credits calculation return 0 credits when there is an insufficient number audience count

Update test for comedy and rename to reflect the expectation for an audience count that does not add credits for most genres

`LineItemProvider.volumeCredits` returns `LineItemTotal`s with correct amounts for genres with attendance counts exceeding base threshold

Remove redundant tests

Use `LineItemProvider` for volume credits when making `StatementData`

Remove unused try and throws